### PR TITLE
Update build.rs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+
+- Changed `ffi_common`'s `build.rs` to use `OUT_DIR`, allowing for `cargo
+    publish`.
+
 ## [0.2.0] - 2020-12-15
 
 ### Added

--- a/ffi_common/build.rs
+++ b/ffi_common/build.rs
@@ -2,7 +2,7 @@ use cbindgen::{Builder, Language};
 use std::env;
 
 fn main() {
-    let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let crate_dir = env::var("OUT_DIR").unwrap();
 
     Builder::new()
         .with_crate(crate_dir)


### PR DESCRIPTION
cargo publish fails because CARGO_MANIFEST_DIR isn't a legal path to change during the publish. Updated to OUT_DIR.