### PR TITLE
DEV-13316 Improve alias resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,9 @@ jobs:
       - name: Setup SSH
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: |
+            ${{ secrets.MAC_OS_BUILD_AGENT_PRIVATE_KEY }}
+            ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -44,7 +46,9 @@ jobs:
       - name: Setup SSH
         uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          ssh-private-key: |
+            ${{ secrets.MAC_OS_BUILD_AGENT_PRIVATE_KEY }}
+            ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,23 @@ members = [
     "ffi_derive",
     "ffi_internals"
 ]
+
+[patch."agrian-registry".ffi_common]
+path = "./ffi_common"
+# git = "ssh://git@github.com/agrian-inc/ffi_common.git"
+# branch = "develop"
+
+[patch."agrian-registry".ffi_consumer]
+path = "./ffi_consumer"
+# git = "ssh://git@github.com/agrian-inc/ffi_common.git"
+# branch = "develop"
+
+[patch."agrian-registry".ffi_derive]
+path = "./ffi_derive"
+# git = "ssh://git@github.com/agrian-inc/ffi_common.git"
+# branch = "develop"
+
+[patch."agrian-registry".ffi_internals]
+path = "./ffi_internals"
+# git = "ssh://git@github.com/agrian-inc/ffi_common.git"
+# branch = "develop"

--- a/ffi_common/src/string.rs
+++ b/ffi_common/src/string.rs
@@ -290,7 +290,7 @@ mod tests {
             let error = crate::error::get_last_err_msg();
             let error_bytes = CStr::from_ptr(error).to_bytes();
             assert!(!error_bytes.is_empty());
-            let original_pointee =  *error;
+            let original_pointee = *error;
             assert_eq!(*error, original_pointee);
             free_rust_string(error);
             assert_ne!(*error, original_pointee);

--- a/ffi_derive/src/lib.rs
+++ b/ffi_derive/src/lib.rs
@@ -52,6 +52,7 @@
 //! 1. Custom `repr(C)` types.
 //! 1. Custom non-`repr(C)` types.
 //! 1. Typealiases over any of the above.
+//! 1. Typealiases defined in remote crates (see `Remote types` section).
 //! 1. Remote types with custom FFI implementations (see `Remote types` section).
 //! 1. A few specific generics:
 //!   1. `Option<T>` where `T` is any supported type (but not nested `Option<Option<T>>`).
@@ -132,6 +133,73 @@
 //!
 //! See `../tests/remote_types` for an example.
 //!
+//! Similarly, sometimes a type we want to expose will reference a typealias defined in a remote
+//! crate. We support that, but because the type information that backs the alias isn't available at
+//! the time procedural macros run, we require some additional configuration in both the module that
+//! defines the alias, and on the type whose fields reference the alias.
+//!
+//! ### Remote alias definitions
+//!
+//! When a module defines aliases that may be referenced by a type that derives an FFI, the
+//! `alias_resolution` attribute macro needs to be run on it in order to populate the definitions of
+//! those aliases somewhere so that we can reference them when resolving the underlying types of
+//! alias references. The macro invocation also needs to define a unique string for the module
+//! (which we refer to internally as the `resolution_key`). This will be used with a helper
+//! attribute on types that derive an FFI so that we can identify the source where their aliases are
+//! defined.
+//!
+//! Invoking the alias resolution macro on a module looks like this:
+//! ```
+//! #[ffi_derive::alias_resolution(some_unique_string)]
+//! mod aliases_here {
+//!     pub type Foo = u8;
+//! }
+//! ```
+//!
+//! Finally, an alias may be defined over another alias (which is odd but happens). We support those
+//! cases, but require an additional helper attribute on the alias declaration to tell us where
+//! *that* alias is defined. For example:
+//! ```ignore
+//! #[ffi_derive::alias_resolution(crate1_aliases)]
+//! mod aliases_in_crate1 {
+//!     pub type Foo = u8;
+//! }
+//!
+//! #[ffi_derive::alias_resolution(crate2_aliases)]
+//! mod aliases_in_crate2 {
+//!     #[nested_alias="crate1_aliases"]
+//!     pub type Bar = Foo;
+//! }
+//! ```
+//!
+//! ### Remote alias references
+//!
+//! When a type derives an FFI includes a field whose type is an alias defined in a remote crate,
+//! the `ffi_derive` macro invocation just needs to include the helper attribute
+//! `ffi(alias_modules("a_key"))` to tell us the resolution key of the module in which those aliases
+//! are defined. For example:
+//! ```ignore
+//! #[ffi_derive::alias_resolution(crate1_aliases)]
+//! mod aliases_in_crate1 {
+//!     pub type Foo = u8;
+//! }
+//!
+//! #[derive(ffi_derive::FFI), ffi(alias_modules("agrian_types_ids"))]
+//! pub struct SomeTypeInCrate2 {
+//!     pub field: Foo
+//! }
+//! ```
+//!
+//! It's worth noting that there's potential for a couple different issues here. First, if a type
+//! provides multiple keys in `alias_modules`, and an identical alias is defined in each of those
+//! modules, we may interpret the type incorrectly. If that scenario comes up, we can work around it
+//! by moving the helper attribute from the struct to the individual fields (since there we only
+//! need to reference one alias_module at a time), but it gets awfully tedious, so we're not doing
+//! that yet. Second, if a type is renamed when it's imported (as in
+//! `use crate1::aliases::Foo as Meow`), or uses a qualified reference instead of an import (as in
+//! `pub field foo: crate1::aliases::Foo`), we won't be able to figure out how to go from that
+//! definition to `Foo` to `u8`.
+//!
 
 #![warn(
     future_incompatible,
@@ -156,13 +224,14 @@
 mod enum_ffi;
 mod struct_ffi;
 
-use ffi_internals::parsing;
+use ffi_internals::{alias_resolution, parsing};
 use heck::SnakeCase;
 use proc_macro::TokenStream;
-use quote::format_ident;
+use quote::{format_ident, ToTokens};
 use syn::{Data, DeriveInput};
 
 /// Derive an FFI for a native type definition.
+///
 #[proc_macro_derive(FFI, attributes(ffi))]
 pub fn ffi_derive(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
@@ -178,19 +247,11 @@ fn impl_ffi_macro(ast: DeriveInput) -> TokenStream {
         "Could not find `CARGO_MANIFEST_DIR` to look up aliases in `ffi_derive::impl_ffi_macro`.",
     );
     let out_dir = option_env!("FFI_CONSUMER_ROOT_DIR").unwrap_or_else(|| env!("OUT_DIR"));
-
     let type_name = ast.ident.clone();
     let module_name = format_ident!("{}_ffi", &type_name.to_string().to_snake_case());
+    let struct_attributes = parsing::parse_struct_attributes(&ast.attrs);
     match ast.data {
         Data::Struct(data) => {
-            let struct_attributes = parsing::parse_struct_attributes(&ast.attrs);
-            let paths: Vec<String> = struct_attributes
-                .alias_paths
-                .iter()
-                .map(|path| format!("{}/{}", crate_root, path))
-                .collect();
-            let alias_map = parsing::type_alias_map(&paths);
-
             if let Some(custom_module_path) = struct_attributes.custom_path {
                 struct_ffi::custom(
                     &type_name,
@@ -199,7 +260,13 @@ fn impl_ffi_macro(ast: DeriveInput) -> TokenStream {
                     out_dir,
                 )
             } else {
-                struct_ffi::standard(module_name, &type_name, data, alias_map, out_dir)
+                struct_ffi::standard(
+                    module_name,
+                    &type_name,
+                    data,
+                    struct_attributes.alias_modules,
+                    out_dir,
+                )
             }
         }
         Data::Enum(_) => {
@@ -211,4 +278,17 @@ fn impl_ffi_macro(ast: DeriveInput) -> TokenStream {
         Data::Union(_) => panic!("Unions are not supported"),
     }
     .into()
+}
+
+/// Parses a module that contains typealiases and stores that information for other ffi_derive calls
+/// to use later in resolving aliases.
+///
+#[proc_macro_attribute]
+pub fn alias_resolution(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let resolution_key = attr.to_string();
+    let module: syn::ItemMod = syn::parse(item.clone())
+        .unwrap_or_else(|e| panic!("Not a module: {:?}. Error: {:?}", item, e));
+    alias_resolution::parse_alias_module(resolution_key, module)
+        .into_token_stream()
+        .into()
 }

--- a/ffi_derive/src/lib.rs
+++ b/ffi_derive/src/lib.rs
@@ -81,9 +81,9 @@
 //! With more complicated structs (the primary focus of this library), you can similarly use a
 //! feature to control when the type is built with `ffi_derive`.
 //!
-//! Typealiases are supported, with the caveat that you have to provide a path to the file(s) in
-//! which any typealiases referenced in the definition of this type are defined (see
-//! `ffi(alias_paths("src/ids.rs"))` in the example below; if `NativeStructId` was an alias over
+//! Typealiases are supported, with the caveat that you have to provide the resolution key for the
+//! module(s) in which any typealiases used in the declaration of this type are defined (see
+//! `ffi(alias_paths(some_module_ids))` in the example below; if `NativeStructId` was an alias over
 //! `Uuid` defined in a file at that path (relative to the root of the crate), we'd figure out what
 //! type to treat that field as for the purposes of FFI.)
 //!
@@ -93,7 +93,7 @@
 //! #[cfg_attr(
 //!     feature = "cffi",
 //!     derive(ffi_derive::FFI),
-//!     ffi(alias_paths("src/ids.rs"))
+//!     ffi(alias_paths(some_module_ids))
 //! )]
 //! #[derive(Clone, Debug)]
 //! pub struct NativeStruct {
@@ -133,18 +133,18 @@
 //!
 //! See `../tests/remote_types` for an example.
 //!
-//! Similarly, sometimes a type we want to expose will reference a typealias defined in a remote
+//! Similarly, sometimes a type we want to expose will use a typealias defined in a remote
 //! crate. We support that, but because the type information that backs the alias isn't available at
 //! the time procedural macros run, we require some additional configuration in both the module that
-//! defines the alias, and on the type whose fields reference the alias.
+//! defines the alias, and on the type whose fields are defined with the alias type.
 //!
 //! ### Remote alias definitions
 //!
-//! When a module defines aliases that may be referenced by a type that derives an FFI, the
+//! When a module defines aliases that may be used on a type that derives an FFI, the
 //! `alias_resolution` attribute macro needs to be run on it in order to populate the definitions of
-//! those aliases somewhere so that we can reference them when resolving the underlying types of
-//! alias references. The macro invocation also needs to define a unique string for the module
-//! (which we refer to internally as the `resolution_key`). This will be used with a helper
+//! those aliases somewhere so that we can look them up when resolving the underlying types of
+//! fields whose type is an alias. The macro invocation also needs to define a unique string for the
+//! module (which we refer to internally as the `resolution_key`). This will be used with a helper
 //! attribute on types that derive an FFI so that we can identify the source where their aliases are
 //! defined.
 //!
@@ -172,11 +172,11 @@
 //! }
 //! ```
 //!
-//! ### Remote alias references
+//! ### Remote aliases in type definitions
 //!
-//! When a type derives an FFI includes a field whose type is an alias defined in a remote crate,
+//! When an `ffi_derive` type includes a field whose type is an alias defined in a remote crate,
 //! the `ffi_derive` macro invocation just needs to include the helper attribute
-//! `ffi(alias_modules("a_key"))` to tell us the resolution key of the module in which those aliases
+//! `ffi(alias_modules(a_key))` to tell us the resolution keys of the modules in which those aliases
 //! are defined. For example:
 //! ```ignore
 //! #[ffi_derive::alias_resolution(crate1_aliases)]
@@ -194,9 +194,9 @@
 //! provides multiple keys in `alias_modules`, and an identical alias is defined in each of those
 //! modules, we may interpret the type incorrectly. If that scenario comes up, we can work around it
 //! by moving the helper attribute from the struct to the individual fields (since there we only
-//! need to reference one alias_module at a time), but it gets awfully tedious, so we're not doing
+//! need to point to one alias_module at a time), but it gets awfully tedious, so we're not doing
 //! that yet. Second, if a type is renamed when it's imported (as in
-//! `use crate1::aliases::Foo as Meow`), or uses a qualified reference instead of an import (as in
+//! `use crate1::aliases::Foo as Meow`), or uses a fully qualified path instead of an import (as in
 //! `pub field foo: crate1::aliases::Foo`), we won't be able to figure out how to go from that
 //! definition to `Foo` to `u8`.
 //!

--- a/ffi_derive/src/struct_ffi.rs
+++ b/ffi_derive/src/struct_ffi.rs
@@ -10,7 +10,7 @@ use ffi_internals::{
 use heck::SnakeCase;
 use proc_macro2::TokenStream;
 use quote::format_ident;
-use std::{collections::HashMap, convert::TryFrom};
+use std::convert::TryFrom;
 use syn::Ident;
 
 pub(super) fn custom(
@@ -58,14 +58,14 @@ pub(super) fn standard(
     module_name: Ident,
     type_name: &Ident,
     data: syn::DataStruct,
-    alias_map: HashMap<Ident, Ident>,
+    alias_modules: Vec<String>,
     out_dir: &str,
 ) -> TokenStream {
     let struct_ffi = StructFFI::try_from(&StructInputs {
         module_name,
         type_name: type_name.clone(),
         data,
-        alias_map,
+        alias_modules,
     })
     .expect("Unsupported struct data");
 

--- a/ffi_derive/tests/memory.rs
+++ b/ffi_derive/tests/memory.rs
@@ -33,6 +33,8 @@ fn check_uuid_vec_memory_after_free() {
 
         assert_eq!(*unsafe_ptr, original_pointee);
         let uuid_struct = uuid_struct_init(string_array);
+        // Flaky test. Nothing guarantees or requires that `unsafe_ptr`'s memory be immediately
+        // changed just because the pointer has been reclaimed and dropped by the Rust allocator.
         assert_ne!(*unsafe_ptr, original_pointee);
         uuid_struct_free(uuid_struct);
     }

--- a/ffi_internals/Cargo.toml
+++ b/ffi_internals/Cargo.toml
@@ -8,8 +8,11 @@ repository = "https://github.com/agrian-inc/ffi_common"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
 ffi_common = { version = "0.2", registry = "agrian-registry" }
 heck = "0.3"
+lazy_static = "1.4.0"
+proc-macro2 = "1.0"
+quote = "1.0"
+serde = "1.0"
+serde_json = "1.0"
+syn = { version = "1.0", features = ["full"] }

--- a/ffi_internals/build.rs
+++ b/ffi_internals/build.rs
@@ -1,0 +1,3 @@
+// This has to exist for Cargo to set the `OUT_DIR` environment variable at compile-time.
+
+fn main() {}

--- a/ffi_internals/src/alias_resolution.rs
+++ b/ffi_internals/src/alias_resolution.rs
@@ -1,0 +1,311 @@
+//!
+//! This module provides methods for parsing aliases out of a module and writing their definitions
+//! to disk, so that when ffi_* macros encounter references to aliases defined in remote crates, the
+//! macros can identify the underlying type so they can determine safe FFI behavior. For example, if
+//! `CrateA` defines
+//! ```ignore
+//! type Foo = u16
+//! ```
+//! and `CrateB` references it
+//! ```ignore
+//! use CrateA::Foo;
+//!
+//! struct Bar { foo: Foo }
+//! ```
+//!
+//! In order to `ffi_derive::FFI`, we need to be able to determine that `Foo` is `u16` and should be
+//! exposed following the same rules as `u16`. This requires us to
+//! # Parse the alias definition into data we can work with in procedural macros.
+//! # Store that data, in a format that support storage of multiple alias sources.
+//! # Read that data while deriving the FFI for types in any other crate.
+//!
+
+use lazy_static::lazy_static;
+use quote::format_ident;
+use std::{collections::HashMap, io::BufRead, sync::Mutex};
+use syn::{Attribute, Ident, Item, ItemMod, ItemType, Lit, Meta::NameValue, Type};
+
+lazy_static! {
+    /// The path to the alias map file, behind a `Mutex` to ensure that multiple operations don't
+    /// attempt to write to it at once (which could result in a corrupted data structure).
+    ///
+    /// This is only an issue for tests since they're executed in parallel; rustc doesn't currently
+    /// do any parallel compilation. Still better to be safe and be able to test it, though.
+    ///
+    static ref ALIAS_MAP_PATH: Mutex<String> = Mutex::new(format!("{}/alias_map.json", env!("OUT_DIR")));
+}
+
+/// Describes the data for a type alias.
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub(super) struct AliasDefinition {
+    /// The type that a newtype is defined as. In `type Foo = u16`, this is `u16`.
+    pub definition: String,
+    /// Set if `definition` is itself an alias, so that we can look at the outer keys again.
+    pub definition_source: Option<String>,
+}
+
+/// Parses `module` to create a hashmap of alias definitions so that we can resolve aliases to their
+/// underlying types when deriving the FFI.
+///
+pub fn parse_alias_module(resolution_key: String, module: ItemMod) -> ItemMod {
+    // Parse the alias resolution data out of `module`.
+    let (brace, items) = module
+        .clone()
+        .content
+        .unwrap_or_else(|| panic!("No module content? {:?}", module));
+    let (stripped_items, new_aliases): (Vec<Item>, HashMap<String, AliasDefinition>) = items
+        .iter()
+        .fold((Vec::<Item>::new(), HashMap::new()), |mut acc, item| {
+            if let Item::Type(item_type) = item {
+                let definition_source = item_type.attrs.iter().find_map(parse_nested_alias_meta);
+                let stripped_attrs: Vec<Attribute> = item_type
+                    .attrs
+                    .clone()
+                    .into_iter()
+                    .filter(|a| parse_nested_alias_meta(a).is_none())
+                    .collect();
+                let new_item_type = ItemType {
+                    attrs: stripped_attrs,
+                    vis: item_type.vis.clone(),
+                    type_token: item_type.type_token,
+                    ident: item_type.ident.clone(),
+                    generics: item_type.generics.clone(),
+                    eq_token: item_type.eq_token,
+                    ty: item_type.ty.clone(),
+                    semi_token: item_type.semi_token,
+                };
+                let new_item = Item::Type(new_item_type);
+                acc.0.push(new_item);
+
+                if let Type::Path(t) = &*item_type.ty {
+                    let segment = t
+                        .path
+                        .segments
+                        .first()
+                        .unwrap_or_else(|| panic!("No path segment? {:?}", t));
+                    acc.1.insert(
+                        item_type.ident.to_string(),
+                        AliasDefinition {
+                            definition: segment.ident.to_string(),
+                            definition_source,
+                        },
+                    );
+                } else {
+                    panic!(
+                        "Found type alias that isn't assigned to a type path. What this? {:?}",
+                        item
+                    );
+                }
+            } else {
+                acc.0.push(item.clone());
+            }
+            acc
+        });
+
+    update_alias_map(resolution_key, new_aliases);
+
+    ItemMod {
+        attrs: module.attrs,
+        vis: module.vis,
+        mod_token: module.mod_token,
+        ident: module.ident,
+        content: Some((brace, stripped_items)),
+        semi: module.semi,
+    }
+}
+
+/// If `field_type` is an alias in `alias_map`, returns the underlying type (resolving aliases
+/// recursively, so if someone is weird and defines typealiases over other typealiases, we'll still
+/// find the underlying type, as long as they were all specified in the `alias_paths` helper
+/// attribute).
+///
+pub(super) fn resolve_type_alias(field_type: &Ident, relevant_modules: &[String]) -> Ident {
+    let alias_map_path = ALIAS_MAP_PATH.lock().unwrap();
+    let aliases: HashMap<String, HashMap<String, AliasDefinition>> =
+        match std::fs::File::open(&*alias_map_path) {
+            Ok(file) => {
+                let reader = std::io::BufReader::new(file);
+                match serde_json::from_reader(reader) {
+                    Ok(result) => result,
+                    Err(e) => panic!("Can't parse the file {}: {}", alias_map_path, e),
+                }
+            }
+            Err(_) => {
+                return field_type.clone();
+            }
+        };
+
+    let aliases_as_idents: HashMap<String, HashMap<Ident, AliasDefinition>> = aliases
+        .iter()
+        .map(|x| {
+            (
+                x.0.clone(),
+                x.1.iter()
+                    .map(|y| (format_ident!("{}", y.0), y.1.clone()))
+                    .collect(),
+            )
+        })
+        .collect();
+
+    let maybe_alias = relevant_modules
+        .iter()
+        .find_map(|m| aliases_as_idents[m].get(field_type));
+
+    match maybe_alias {
+        Some(alias) => {
+            let field_type = format_ident!("{}", alias.definition);
+            let modules_to_check = match &alias.definition_source {
+                Some(source) => vec![source.to_owned()],
+                None => relevant_modules.to_owned(),
+            };
+            // We need to manually drop alias_map_path here because we're calling
+            // `resolve_type_alias` recursively, which will cause us to try to get another lock on
+            // `ALIAS_MAP_PATH` on the same thread (which will either deadlock or panic).
+            drop(alias_map_path);
+            resolve_type_alias(&field_type, &*modules_to_check)
+        }
+        None => field_type.clone(),
+    }
+}
+
+/// Updates the alias_map file on disk with a new map of aliases under the `resolution_key`.
+///
+fn update_alias_map(resolution_key: String, new_aliases: HashMap<String, AliasDefinition>) {
+    // Read the existing file so we can add to it, or, if it doesn't exist, initialize an empty
+    // `HashMap`.
+    let alias_map_path = ALIAS_MAP_PATH.lock().unwrap();
+    let mut map: HashMap<String, HashMap<String, AliasDefinition>> =
+        match std::fs::OpenOptions::new()
+            .read(true)
+            .open(&*alias_map_path)
+        {
+            Ok(file) => {
+                let mut reader = std::io::BufReader::new(file);
+                if reader.fill_buf().ok().unwrap().is_empty() {
+                    HashMap::new()
+                } else {
+                    match serde_json::from_reader(reader) {
+                        Ok(result) => result,
+                        Err(e) => panic!("Can't parse the file {}: {}", alias_map_path, e),
+                    }
+                }
+            }
+            Err(_) => HashMap::new(),
+        };
+    map.insert(resolution_key, new_aliases);
+
+    // Write `map`, which now also inclues the new alias resolution data for `module`, back to disk.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .open(&*alias_map_path)
+    {
+        Ok(file) => match serde_json::to_writer(file, &map) {
+            Ok(_) => {}
+            Err(e) => println!("Error writing file {}: {}", alias_map_path, e),
+        },
+        Err(e) => println!("Error opening file {}: {}", alias_map_path, e),
+    };
+}
+
+/// Reads the `nested_alias` helper attribute, returning `Some(attribute_value)` if it is found,
+/// otherwise `None`.
+///
+fn parse_nested_alias_meta(attr: &Attribute) -> Option<String> {
+    if !attr.path.is_ident("nested_alias") {
+        return None;
+    }
+    match attr.parse_meta() {
+        Ok(NameValue(name_value)) => {
+            if let Lit::Str(s) = name_value.lit {
+                return Some(s.value());
+            }
+            panic!("Unexpected nested_alias value: {:?}", name_value);
+        }
+        Ok(other) => {
+            panic!("Unexpected meta attribute found: {:?}", other);
+        }
+        Err(err) => {
+            panic!("Error parsing meta attribute: {:?}", err);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RESOLUTION_KEY1: &str = "test_module_key1";
+    const RESOLUTION_KEY2: &str = "test_module_key2";
+
+    fn setup() {
+        // Configure the alias map file with the alias data we'd pull out of a module.
+        let mut aliases1 = HashMap::new();
+        aliases1.insert(
+            "alias1".to_string(),
+            AliasDefinition {
+                definition: "u8".to_string(),
+                definition_source: None,
+            },
+        );
+        aliases1.insert(
+            "alias2".to_string(),
+            AliasDefinition {
+                definition: "String".to_string(),
+                definition_source: None,
+            },
+        );
+        update_alias_map(RESOLUTION_KEY1.to_string(), aliases1);
+
+        // Configure another module's alias data, including one that references an alias from the
+        // first module.
+        let mut aliases2 = HashMap::new();
+        aliases2.insert(
+            "alias3".to_string(),
+            AliasDefinition {
+                definition: "u16".to_string(),
+                definition_source: None,
+            },
+        );
+        aliases2.insert(
+            "alias4".to_string(),
+            AliasDefinition {
+                definition: "alias1".to_string(),
+                definition_source: Some(RESOLUTION_KEY1.to_string()),
+            },
+        );
+        update_alias_map(RESOLUTION_KEY2.to_string(), aliases2);
+    }
+
+    #[test]
+    fn test_simple_alias_resolution() {
+        setup();
+
+        let field_type = format_ident!("alias1");
+        let relevant_modules = [RESOLUTION_KEY1.to_string()];
+        let expected = format_ident!("u8");
+        assert_eq!(expected, resolve_type_alias(&field_type, &relevant_modules));
+    }
+
+    #[test]
+    fn test_nested_alias_resolution() {
+        setup();
+
+        let field_type = format_ident!("alias4");
+        let relevant_modules = [RESOLUTION_KEY2.to_string()];
+        let expected = format_ident!("u8");
+        assert_eq!(expected, resolve_type_alias(&field_type, &relevant_modules));
+    }
+
+    #[test]
+    fn test_non_alias_type() {
+        setup();
+
+        let field_type = format_ident!("i32");
+        let relevant_modules = [RESOLUTION_KEY2.to_string()];
+        assert_eq!(
+            field_type,
+            resolve_type_alias(&field_type, &relevant_modules)
+        );
+    }
+}

--- a/ffi_internals/src/lib.rs
+++ b/ffi_internals/src/lib.rs
@@ -6,6 +6,7 @@
 //! which has more general FFI stuff.
 //!
 
+pub mod alias_resolution;
 pub mod field_ffi;
 pub mod native_type_data;
 pub mod parsing;

--- a/ffi_internals/src/parsing.rs
+++ b/ffi_internals/src/parsing.rs
@@ -203,19 +203,14 @@ pub(super) fn parse_field_attributes(attrs: &[Attribute]) -> crate::field_ffi::F
 ///
 fn parse_alias_modules(arg: &NestedMeta) -> Vec<String> {
     match arg {
+        Meta(Path(path)) => {
+            return path.segments.iter().map(|s| s.ident.to_string()).collect();
+        }
         Meta(_) => {
             panic!("Unexpected meta attribute {:?}", arg);
         }
         NestedMeta::Lit(lit) => {
-            if let Lit::Str(lit_str) = lit {
-                lit_str
-                    .value()
-                    .split(',')
-                    .map(|s| s.trim().to_string())
-                    .collect()
-            } else {
-                panic!("Non-string literal attribute: {:?}", lit)
-            }
+            panic!("Unexpected literal attribute {:?}", lit);
         }
     }
 }

--- a/ffi_internals/src/struct_ffi.rs
+++ b/ffi_internals/src/struct_ffi.rs
@@ -7,10 +7,7 @@ use crate::field_ffi::FieldFFI;
 use heck::SnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use std::{
-    collections::{HashMap, HashSet},
-    convert::TryFrom,
-};
+use std::{collections::HashSet, convert::TryFrom};
 use syn::{Fields, Ident};
 
 pub struct StructFFI {
@@ -56,7 +53,7 @@ pub struct StructInputs {
     pub module_name: Ident,
     pub type_name: Ident,
     pub data: syn::DataStruct,
-    pub alias_map: HashMap<Ident, Ident>,
+    pub alias_modules: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -78,7 +75,7 @@ impl TryFrom<&StructInputs> for StructFFI {
         }
         .named
         .iter()
-        .map(|field| FieldFFI::from((derive.type_name.clone(), field, &derive.alias_map)))
+        .map(|field| FieldFFI::from((derive.type_name.clone(), field, &*derive.alias_modules)))
         .collect();
 
         let (init_arguments, assignment_expressions, getter_fns) =


### PR DESCRIPTION
Add an attribute macro for getting alias resolution details out of a
module early on (during proc macro expansion, before type analysis).
Write it to a file in the out dir, and read it when deriving FFI.

Alternatives tried:
1. Using the attribute macro to generate an alias_resolution macro
(no good because that macro isn't callable during the proc macro step
where derive is invoked)
2. Using a global variable instead of writing a file (no good because
the macro runs as a separate process for each crate, so alias
resolution info acquired while parsing agrian_types is not available
when parsing commodity_locationizer).
