### PR TITLE
DEV-16437 Harden alias resolution

### DIFF
--- a/ffi_derive/src/lib.rs
+++ b/ffi_derive/src/lib.rs
@@ -362,6 +362,7 @@ pub fn alias_resolution(attr: TokenStream, item: TokenStream) -> TokenStream {
     let resolution_key = attr.to_string();
     let module = parse_macro_input!(item as ItemMod);
     alias_resolution::parse_alias_module(resolution_key, module)
+        .unwrap()
         .into_token_stream()
         .into()
 }

--- a/ffi_internals/Cargo.toml
+++ b/ffi_internals/Cargo.toml
@@ -16,3 +16,4 @@ quote = "1.0"
 serde = "1.0"
 serde_json = "1.0"
 syn = { version = "1.0", features = ["full"] }
+thiserror = "1.0"

--- a/ffi_internals/src/alias_resolution.rs
+++ b/ffi_internals/src/alias_resolution.rs
@@ -22,8 +22,11 @@
 
 use lazy_static::lazy_static;
 use quote::format_ident;
-use std::{collections::HashMap, io::BufRead, sync::Mutex};
-use syn::{Attribute, Ident, Item, ItemMod, ItemType, Lit, Meta::NameValue, Type};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, MutexGuard},
+};
+use syn::{Attribute, Ident, Item, ItemMod, ItemType, Lit, Meta::NameValue, Type, TypePath};
 
 lazy_static! {
     /// The path to the alias map file, behind a `Mutex` to ensure that multiple operations don't
@@ -35,8 +38,42 @@ lazy_static! {
     static ref ALIAS_MAP_PATH: Mutex<String> = Mutex::new(format!("{}/alias_map.json", env!("OUT_DIR")));
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Unsupported ItemType: `{0:?}`")]
+    UnexpectedType(Item),
+    #[error("No path segments in TypePath: `{0:?}`")]
+    MissingPath(TypePath),
+    #[error("serde_json error: `{0}`")]
+    Serde(serde_json::Error),
+    #[error("IO error: `{0}`")]
+    Io(std::io::Error),
+    #[error("No module content found for ItemMod: `{0:?}`")]
+    EmptyModule(ItemMod),
+    #[error("Mutex error: `{0}`")]
+    Mutex(String),
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(e: serde_json::Error) -> Self {
+        Self::Serde(e)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl<T> From<std::sync::PoisonError<T>> for Error {
+    fn from(e: std::sync::PoisonError<T>) -> Self {
+        Self::Mutex(e.to_string())
+    }
+}
+
 /// Describes the data for a type alias.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 struct AliasDefinition {
     /// The type that a newtype is defined as. In `type Foo = u16`, this is `u16`.
     definition: String,
@@ -47,7 +84,12 @@ struct AliasDefinition {
 /// Parses `module` to create a hashmap of alias definitions so that we can resolve aliases to their
 /// underlying types when deriving the FFI.
 ///
-pub fn parse_alias_module(resolution_key: String, module: ItemMod) -> ItemMod {
+/// # Errors
+///
+/// This function will return an error if anything goes wrong when parsing data out of `module`,
+/// getting a lock on the file path, reading the file, or parsing the file's JSON.
+///
+pub fn parse_alias_module(resolution_key: String, module: ItemMod) -> Result<ItemMod, Error> {
     #[derive(Default)]
     struct ModuleOutput {
         stripped_items: Vec<Item>,
@@ -55,68 +97,50 @@ pub fn parse_alias_module(resolution_key: String, module: ItemMod) -> ItemMod {
     }
 
     // Parse the alias resolution data out of `module`.
-    let (brace, items) = module
-        .clone()
-        .content
-        .unwrap_or_else(|| panic!("No module content? {:?}", module));
+    let (brace, items) = match module.clone().content {
+        Some((b, i)) => (b, i),
+        None => return Err(Error::EmptyModule(module)),
+    };
     let module_output: ModuleOutput =
-        items.iter().fold(ModuleOutput::default(), |mut acc, item| {
-            if let Item::Type(item_type) = item {
-                let definition_source = item_type.attrs.iter().find_map(parse_nested_alias_meta);
-                let stripped_attrs: Vec<Attribute> = item_type
-                    .attrs
-                    .clone()
-                    .into_iter()
-                    .filter(|a| parse_nested_alias_meta(a).is_none())
-                    .collect();
-                let new_item_type = ItemType {
-                    attrs: stripped_attrs,
-                    vis: item_type.vis.clone(),
-                    type_token: item_type.type_token,
-                    ident: item_type.ident.clone(),
-                    generics: item_type.generics.clone(),
-                    eq_token: item_type.eq_token,
-                    ty: item_type.ty.clone(),
-                    semi_token: item_type.semi_token,
-                };
-                let new_item = Item::Type(new_item_type);
-                acc.stripped_items.push(new_item);
+        items
+            .iter()
+            .try_fold(ModuleOutput::default(), |mut acc, item| {
+                if let Item::Type(item_type) = item {
+                    let definition_source =
+                        item_type.attrs.iter().find_map(parse_nested_alias_meta);
+                    let new_item = strip_alias_attribute(item_type);
+                    acc.stripped_items.push(new_item);
 
-                if let Type::Path(t) = &*item_type.ty {
-                    let segment = t
-                        .path
-                        .segments
-                        .first()
-                        .unwrap_or_else(|| panic!("No path segment? {:?}", t));
-                    acc.new_aliases.insert(
-                        item_type.ident.to_string(),
-                        AliasDefinition {
+                    if let Type::Path(t) = &*item_type.ty {
+                        let segment = match t.path.segments.first() {
+                            Some(s) => s,
+                            None => return Err(Error::MissingPath(t.clone())),
+                        };
+                        *acc.new_aliases
+                            .entry(item_type.ident.to_string())
+                            .or_default() = AliasDefinition {
                             definition: segment.ident.to_string(),
                             definition_source,
-                        },
-                    );
+                        };
+                    } else {
+                        return Err(Error::UnexpectedType(item.clone()));
+                    }
                 } else {
-                    panic!(
-                        "Found type alias that isn't assigned to a type path. What this? {:?}",
-                        item
-                    );
+                    acc.stripped_items.push(item.clone());
                 }
-            } else {
-                acc.stripped_items.push(item.clone());
-            }
-            acc
-        });
+                Ok(acc)
+            })?;
 
-    update_alias_map(resolution_key, module_output.new_aliases);
+    update_alias_map(resolution_key, module_output.new_aliases)?;
 
-    ItemMod {
+    Ok(ItemMod {
         attrs: module.attrs,
         vis: module.vis,
         mod_token: module.mod_token,
         ident: module.ident,
         content: Some((brace, module_output.stripped_items)),
         semi: module.semi,
-    }
+    })
 }
 
 /// If `type_name` is an alias in `alias_map`, returns the underlying type (resolving aliases
@@ -124,19 +148,30 @@ pub fn parse_alias_module(resolution_key: String, module: ItemMod) -> ItemMod {
 /// find the underlying type, as long as they were all specified in the `alias_paths` helper
 /// attribute).
 ///
-pub(super) fn resolve_type_alias(type_name: &Ident, relevant_modules: &[String]) -> Ident {
-    let alias_map_path = ALIAS_MAP_PATH.lock().unwrap();
+/// # Errors
+///
+/// This function will return an error if anything goes wrong when getting a lock on the file path,
+/// reading the file, or parsing the file's JSON.
+///
+pub(super) fn resolve_type_alias(
+    type_name: &Ident,
+    relevant_modules: &[String],
+    alias_map_path: Option<MutexGuard<String>>,
+) -> Result<Ident, Error> {
+    // Use the path that was passed in (if we already have it and therefore have a lock on it), or
+    // get a lock on the path to the alias map file.
+    let alias_map_path = match alias_map_path {
+        Some(p) => p,
+        None => ALIAS_MAP_PATH.lock()?,
+    };
     let aliases: HashMap<String, HashMap<String, AliasDefinition>> =
         match std::fs::File::open(&*alias_map_path) {
             Ok(file) => {
                 let reader = std::io::BufReader::new(file);
-                match serde_json::from_reader(reader) {
-                    Ok(result) => result,
-                    Err(e) => panic!("Can't parse the file {}: {}", alias_map_path, e),
-                }
+                serde_json::from_reader(reader)?
             }
             Err(_) => {
-                return type_name.clone();
+                return Ok(type_name.clone());
             }
         };
 
@@ -160,54 +195,71 @@ pub(super) fn resolve_type_alias(type_name: &Ident, relevant_modules: &[String])
         Some(alias) => {
             let field_type = format_ident!("{}", alias.definition);
             let modules_to_check = match &alias.definition_source {
-                Some(source) => vec![source.to_owned()],
+                Some(source) => vec![source.clone()],
                 None => relevant_modules.to_owned(),
             };
-            // We need to manually drop alias_map_path here because we're calling
-            // `resolve_type_alias` recursively, which will cause us to try to get another lock on
-            // `ALIAS_MAP_PATH` on the same thread (which will either deadlock or panic).
-            drop(alias_map_path);
-            resolve_type_alias(&field_type, &*modules_to_check)
+            resolve_type_alias(&field_type, &*modules_to_check, Some(alias_map_path))
         }
-        None => type_name.clone(),
+        None => Ok(type_name.clone()),
     }
 }
 
-/// Updates the alias_map file on disk with a new map of aliases under the `resolution_key`.
+/// Strips the `nested_alias` attribute off of an `&ItemType`'s attributes and returns an `Item`
+/// constructed from its other data. The resulting `Item` can be safely sent back to the
+/// `TokenStream` and will no longer have the attribute used by the `alias_resolution` attribute
+/// macro.
 ///
-fn update_alias_map(resolution_key: String, new_aliases: HashMap<String, AliasDefinition>) {
+fn strip_alias_attribute(item_type: &ItemType) -> Item {
+    let stripped_attrs: Vec<Attribute> = item_type
+        .attrs
+        .clone()
+        .into_iter()
+        .filter(|a| parse_nested_alias_meta(a).is_none())
+        .collect();
+    let new_item_type = ItemType {
+        attrs: stripped_attrs,
+        vis: item_type.vis.clone(),
+        type_token: item_type.type_token,
+        ident: item_type.ident.clone(),
+        generics: item_type.generics.clone(),
+        eq_token: item_type.eq_token,
+        ty: item_type.ty.clone(),
+        semi_token: item_type.semi_token,
+    };
+    Item::Type(new_item_type)
+}
+
+/// Updates the `alias_map` file on disk with a new map of aliases under the `resolution_key`.
+///
+/// # Errors
+///
+/// This function will return an error if anything goes wrong when getting a lock on the file path,
+/// reading or writing the file, or parsing the file's JSON.
+///
+fn update_alias_map(
+    resolution_key: String,
+    new_aliases: HashMap<String, AliasDefinition>,
+) -> Result<(), Error> {
     // Read the existing file so we can add to it, or, if it doesn't exist, initialize an empty
     // `HashMap`.
-    let alias_map_path = ALIAS_MAP_PATH.lock().unwrap();
+    let alias_map_path = ALIAS_MAP_PATH.lock()?;
     let mut map: HashMap<String, HashMap<String, AliasDefinition>> =
         match std::fs::OpenOptions::new()
             .read(true)
             .open(&*alias_map_path)
         {
             Ok(file) => {
-                let mut reader = std::io::BufReader::new(file);
-                if reader.fill_buf().ok().unwrap().is_empty() {
-                    HashMap::new()
-                } else {
-                    match serde_json::from_reader(reader) {
-                        Ok(result) => result,
-                        Err(e) => panic!("Can't parse the file {}: {}", alias_map_path, e),
-                    }
-                }
+                let reader = std::io::BufReader::new(file);
+                serde_json::from_reader(reader)?
             }
             Err(_) => HashMap::new(),
         };
-    map.insert(resolution_key, new_aliases);
+
+    *map.entry(resolution_key).or_default() = new_aliases;
 
     // Write `map`, which now also inclues the new alias resolution data for `module`, back to disk.
-    let file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .open(&*alias_map_path)
-        .unwrap_or_else(|e| panic!("Error opening file to write {}: {}", alias_map_path, e));
-
-    serde_json::to_writer(file, &map)
-        .unwrap_or_else(|e| println!("Error writing file {}: {}", alias_map_path, e));
+    std::fs::write(&*alias_map_path, serde_json::to_string(&map)?)?;
+    Ok(())
 }
 
 /// Reads the `nested_alias` helper attribute, returning `Some(attribute_value)` if it is found,
@@ -240,74 +292,72 @@ mod tests {
     const RESOLUTION_KEY1: &str = "test_module_key1";
     const RESOLUTION_KEY2: &str = "test_module_key2";
 
-    fn setup() {
+    fn setup() -> Result<(), Error> {
         // Configure the alias map file with the alias data we'd pull out of a module.
         let mut aliases1 = HashMap::new();
-        aliases1.insert(
-            "alias1".to_string(),
-            AliasDefinition {
-                definition: "u8".to_string(),
-                definition_source: None,
-            },
-        );
-        aliases1.insert(
-            "alias2".to_string(),
-            AliasDefinition {
-                definition: "String".to_string(),
-                definition_source: None,
-            },
-        );
-        update_alias_map(RESOLUTION_KEY1.to_string(), aliases1);
+        *aliases1.entry("alias1".to_string()).or_default() = AliasDefinition {
+            definition: "u8".to_string(),
+            definition_source: None,
+        };
+        *aliases1.entry("alias2".to_string()).or_default() = AliasDefinition {
+            definition: "String".to_string(),
+            definition_source: None,
+        };
+        update_alias_map(RESOLUTION_KEY1.to_string(), aliases1)?;
 
         // Configure another module's alias data, including one that references an alias from the
         // first module.
         let mut aliases2 = HashMap::new();
-        aliases2.insert(
-            "alias3".to_string(),
-            AliasDefinition {
-                definition: "u16".to_string(),
-                definition_source: None,
-            },
-        );
-        aliases2.insert(
-            "alias4".to_string(),
-            AliasDefinition {
-                definition: "alias1".to_string(),
-                definition_source: Some(RESOLUTION_KEY1.to_string()),
-            },
-        );
-        update_alias_map(RESOLUTION_KEY2.to_string(), aliases2);
+        *aliases2.entry("alias3".to_string()).or_default() = AliasDefinition {
+            definition: "u16".to_string(),
+            definition_source: None,
+        };
+        *aliases2.entry("alias4".to_string()).or_default() = AliasDefinition {
+            definition: "alias1".to_string(),
+            definition_source: Some(RESOLUTION_KEY1.to_string()),
+        };
+        update_alias_map(RESOLUTION_KEY2.to_string(), aliases2)?;
+        Ok(())
     }
 
     #[test]
-    fn test_simple_alias_resolution() {
-        setup();
+    fn test_simple_alias_resolution() -> Result<(), Error> {
+        setup()?;
 
         let field_type = format_ident!("alias1");
         let relevant_modules = [RESOLUTION_KEY1.to_string()];
         let expected = format_ident!("u8");
-        assert_eq!(expected, resolve_type_alias(&field_type, &relevant_modules));
+        assert_eq!(
+            expected,
+            resolve_type_alias(&field_type, &relevant_modules, None).unwrap()
+        );
+        Ok(())
     }
 
     #[test]
-    fn test_nested_alias_resolution() {
-        setup();
+    fn test_nested_alias_resolution() -> Result<(), Error> {
+        setup()?;
 
         let field_type = format_ident!("alias4");
         let relevant_modules = [RESOLUTION_KEY2.to_string()];
         let expected = format_ident!("u8");
-        assert_eq!(expected, resolve_type_alias(&field_type, &relevant_modules));
+        assert_eq!(
+            expected,
+            resolve_type_alias(&field_type, &relevant_modules, None).unwrap()
+        );
+        Ok(())
     }
 
     #[test]
-    fn test_non_alias_type() {
-        setup();
+    fn test_non_alias_type() -> Result<(), Error> {
+        setup()?;
 
         let field_type = format_ident!("i32");
         let relevant_modules = [RESOLUTION_KEY2.to_string()];
         assert_eq!(
             field_type,
-            resolve_type_alias(&field_type, &relevant_modules)
+            resolve_type_alias(&field_type, &relevant_modules, None).unwrap()
         );
+        Ok(())
     }
 }

--- a/ffi_internals/src/native_type_data.rs
+++ b/ffi_internals/src/native_type_data.rs
@@ -486,7 +486,7 @@ impl NativeTypeData {
 /// Returns a `NativeTypeData` describing the native type for a custom FFI type, so we can use that
 /// structure to generate the consumer structure just like we do with generated FFIs.
 ///
-pub fn native_type_data_for_custom(ffi_type: &syn::Type) -> NativeTypeData {
+pub fn native_type_data_for_custom(ffi_type: &Type) -> NativeTypeData {
     match ffi_type {
         Type::Path(type_path) => {
             let (ident, wrapping_type) = parsing::separate_wrapping_type_from_inner_type(

--- a/ffi_internals/src/parsing/field_attributes.rs
+++ b/ffi_internals/src/parsing/field_attributes.rs
@@ -36,7 +36,7 @@ impl FieldAttributes {
 
 impl From<&[Attribute]> for FieldAttributes {
     fn from(attrs: &[Attribute]) -> Self {
-        let mut expose_as: Option<syn::Path> = None;
+        let mut expose_as: Option<Path> = None;
         let mut raw = false;
         for meta_item in attrs.iter().flat_map(super::parse_ffi_meta).flatten() {
             match &meta_item {

--- a/ffi_internals/src/struct_internals/field_ffi.rs
+++ b/ffi_internals/src/struct_internals/field_ffi.rs
@@ -191,7 +191,7 @@ impl From<(Ident, &Field, &[String])> for FieldFFI {
                     parsing::separate_wrapping_type_from_inner_type(segment);
                 (
                     wrapping_type,
-                    alias_resolution::resolve_type_alias(&ident, alias_modules),
+                    alias_resolution::resolve_type_alias(&ident, alias_modules, None).unwrap(),
                 )
             }
             None => panic!("No path segment (field without a type?)"),

--- a/ffi_internals/src/struct_internals/struct_ffi.rs
+++ b/ffi_internals/src/struct_internals/struct_ffi.rs
@@ -41,7 +41,7 @@ impl StructFFI {
             .as_slice()
             .iter()
             .filter_map(|f| f.attributes.expose_as.as_ref())
-            .collect::<HashSet<&syn::Path>>()
+            .collect::<HashSet<&Path>>()
             .iter()
             .fold(quote!(), |mut acc, path| {
                 acc.extend(quote!(use #path;));


### PR DESCRIPTION
Remove most of the panics from `ffi_internals::alias_resolution` and
bubble up whatever goes wrong into a new `Error` type. We're still
unwrapping _that_ error, but now it's unwrapped in the attribute macro
itself, so it's a little easier to follow and will be easier to do
better error handling later.

Change `resolve_type_alias` to take an optional path to the resolution
file. This lets us keep and reuse a single lock on the `ALIAS_MAP_PATH`
mutex, instead of manually dropping it (unlocking the mutex) before each
recursive call.

Replace the use of `serde_json::to_writer` with `std::fs::write`. The
serde_json method doesn't necessarily replace the entire contents of the
file, which I think led to the broken JSON (if a larger `HashMap` was
already written, writing a smaller one would overwrite _part_ of that,
leaving a weirdly incomplete structure).

Clean up some of the file read/write calls and the `HashMap` mutations.
Fix some warnings.
