### PR TITLE
release/0.5.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
   test_ios:
     name: Test (x86_64-apple-ios)
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
       DYLD_ROOT_PATH: '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app'
     steps:

--- a/ffi_common/Cargo.toml
+++ b/ffi_common/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "ffi_common"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
 repository = "https://github.com/agrian-inc/ffi_common"
 
 [dependencies]
-ffi_core = { version = "0.5.0", registry = "agrian-registry" }
-ffi_derive = { version = "0.5.0", registry = "agrian-registry" }
-ffi_internals = { version = "0.5.0", registry = "agrian-registry" }
+ffi_core = { version = "0.5.1", registry = "agrian-registry" }
+ffi_derive = { version = "0.5.1", registry = "agrian-registry" }
+ffi_internals = { version = "0.5.1", registry = "agrian-registry" }
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/ffi_common/tests/memory.rs
+++ b/ffi_common/tests/memory.rs
@@ -32,8 +32,8 @@ fn check_uuid_vec_init_and_free() {
         let original_pointee = *unsafe_ptr;
 
         assert_eq!(*unsafe_ptr, original_pointee);
-        let uuid_struct = uuid_struct_init(string_array);
-        uuid_struct_free(uuid_struct);
+        let uuid_struct = uuid_struct_rust_ffi_init(string_array);
+        uuid_struct_rust_ffi_free(uuid_struct);
     }
 }
 
@@ -42,15 +42,15 @@ fn check_struct_vec_init_and_free() {
     unsafe {
         let ids1 = vec![Uuid::new_v4(), Uuid::new_v4()];
         let ids2 = vec![Uuid::new_v4(), Uuid::new_v4()];
-        let inner_struct1 = *Box::from_raw(uuid_struct_init((&*ids1).into()) as *mut _);
-        let inner_struct2 = *Box::from_raw(uuid_struct_init((&*ids2).into()) as *mut _);
+        let inner_struct1 = *Box::from_raw(uuid_struct_rust_ffi_init((&*ids1).into()) as *mut _);
+        let inner_struct2 = *Box::from_raw(uuid_struct_rust_ffi_init((&*ids2).into()) as *mut _);
         let v = vec![inner_struct1, inner_struct2];
         let inner_array = FFIArrayUuidStruct::from(&*v);
         let unsafe_ptr = inner_array.ptr;
         let original_value = *unsafe_ptr;
 
         assert_eq!(*unsafe_ptr, original_value);
-        let outer_struct = nested_struct_ffi::nested_struct_init(inner_array);
-        nested_struct_ffi::nested_struct_free(outer_struct);
+        let outer_struct = nested_struct_ffi::nested_struct_rust_ffi_init(inner_array);
+        nested_struct_ffi::nested_struct_rust_ffi_free(outer_struct);
     }
 }

--- a/ffi_common/tests/remote_types.rs
+++ b/ffi_common/tests/remote_types.rs
@@ -33,11 +33,11 @@ pub struct StructWithRemoteTypeFields {
 fn test_remote_wrapper() {
     unsafe {
         let wrapper =
-            date_time_wrapper_ffi::date_time_wrapper_init(ffi_string!("2020-10-27T16:30:52Z"));
+            date_time_wrapper_ffi::date_time_wrapper_rust_ffi_init(ffi_string!("2020-10-27T16:30:52Z"));
         // `wrapper` is consumed here; note that even with wrapped remote types, arguments passed to an
         // FFI initializer are considered `move`s.
         let struct_with_remote =
-            struct_with_remote_type_fields_ffi::struct_with_remote_type_fields_init(
+            struct_with_remote_type_fields_ffi::struct_with_remote_type_fields_rust_ffi_init(
                 42,
                 wrapper as *mut DateTimeWrapper,
             );
@@ -45,6 +45,6 @@ fn test_remote_wrapper() {
             (*struct_with_remote).remote.to_string(),
             "2020-10-27 16:30:52 UTC"
         );
-        struct_with_remote_type_fields_ffi::struct_with_remote_type_fields_free(struct_with_remote);
+        struct_with_remote_type_fields_ffi::struct_with_remote_type_fields_rust_ffi_free(struct_with_remote);
     }
 }

--- a/ffi_common/tests/struct_field_access.rs
+++ b/ffi_common/tests/struct_field_access.rs
@@ -72,7 +72,7 @@ fn test_struct_ffi() {
         let ffi_date_array = FFIArrayTimeStamp::from(input_date_vec.as_deref());
 
         // Initialize the test instance through the ffi init, getting back a pointer to it.
-        let test_struct = test_struct_ffi::test_struct_init(
+        let test_struct = test_struct_ffi::test_struct_rust_ffi_init(
             ffi_string,
             ffi_i32_array,
             variant,
@@ -115,6 +115,6 @@ fn test_struct_ffi() {
         );
 
         // Free the thing.
-        test_struct_free(test_struct);
+        test_struct_rust_ffi_free(test_struct);
     }
 }

--- a/ffi_common/tests/tuple_structs.rs
+++ b/ffi_common/tests/tuple_structs.rs
@@ -12,9 +12,9 @@ fn access_wrapper_ffo() {
     let value1 = 42;
     let value2 = 99;
     unsafe {
-        let input1 = some_type_ffi::some_type_init(value1) as *mut SomeType;
-        let input2 = some_type_ffi::some_type_init(value2) as *mut SomeType;
-        let wrapper = wrapper_ffi::wrapper_init(input1, input2);
+        let input1 = some_type_ffi::some_type_rust_ffi_init(value1) as *mut SomeType;
+        let input2 = some_type_ffi::some_type_rust_ffi_init(value2) as *mut SomeType;
+        let wrapper = wrapper_ffi::wrapper_rust_ffi_init(input1, input2);
         let output1 = wrapper_ffi::get_wrapper_unnamed_field_0(wrapper);
         let output2 = wrapper_ffi::get_wrapper_unnamed_field_1(wrapper);
         assert_eq!(value1, (*output1).value);

--- a/ffi_core/Cargo.toml
+++ b/ffi_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_core"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]

--- a/ffi_derive/Cargo.toml
+++ b/ffi_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_derive"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
@@ -10,9 +10,9 @@ repository = "https://github.com/agrian-inc/ffi_common"
 proc-macro = true
 
 [dependencies]
-ffi_internals = { version = "0.5.0", registry = "agrian-registry" }
+ffi_internals = { version = "0.5.1", registry = "agrian-registry" }
 proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 
 [build-dependencies]
-ffi_internals = { version = "0.5.0", registry = "agrian-registry" }
+ffi_internals = { version = "0.5.1", registry = "agrian-registry" }

--- a/ffi_internals/Cargo.toml
+++ b/ffi_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_internals"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
@@ -10,7 +10,7 @@ repository = "https://github.com/agrian-inc/ffi_common"
 
 [dependencies]
 chrono = "0.4"
-ffi_core = { version = "0.5.0", registry = "agrian-registry" }
+ffi_core = { version = "0.5.1", registry = "agrian-registry" }
 heck = "0.3"
 lazy_static = "1.4.0"
 paste = "1.0.0"

--- a/ffi_internals/src/struct_internals/struct_ffi.rs
+++ b/ffi_internals/src/struct_internals/struct_ffi.rs
@@ -45,21 +45,21 @@ impl StructFFI {
     ///
     #[must_use]
     pub fn init_fn_name(&self) -> Ident {
-        format_ident!("{}_init", self.name.to_string().to_snake_case())
+        format_ident!("{}_rust_ffi_init", self.name.to_string().to_snake_case())
     }
 
     /// The name of the free function for this struct.
     ///
     #[must_use]
     pub fn free_fn_name(&self) -> Ident {
-        format_ident!("{}_free", self.name.to_string().to_snake_case())
+        format_ident!("{}_rust_ffi_free", self.name.to_string().to_snake_case())
     }
 
     /// The name of the clone function for this struct.
     ///
     #[must_use]
     pub fn clone_fn_name(&self) -> Ident {
-        format_ident!("clone_{}", self.name.to_string().to_snake_case())
+        format_ident!("rust_ffi_clone_{}", self.name.to_string().to_snake_case())
     }
 
     /// Find any extra imports from `expose_as` attributes on this struct's fields, and return them


### PR DESCRIPTION
- Fix GH action.
- Change the names of the generated FFI init/free/clone methods.
- ffi_common: Bump to 0.5.1
- ffi_internals: Bump to 0.5.1
- ffi_derive: Bump to 0.5.1
- ffi_common: Bump to 0.5.1
