### PR TITLE
release/0.6.0

### DIFF
--- a/ffi_common/Cargo.toml
+++ b/ffi_common/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "ffi_common"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
 repository = "https://github.com/agrian-inc/ffi_common"
 
 [dependencies]
-ffi_core = { version = "0.5.1", registry = "agrian-registry" }
-ffi_derive = { version = "0.5.1", registry = "agrian-registry" }
-ffi_internals = { version = "0.5.1", registry = "agrian-registry" }
+ffi_core = { version = "0.6.0", registry = "agrian-registry" }
+ffi_derive = { version = "0.6.0", registry = "agrian-registry" }
+ffi_internals = { version = "0.6.0", registry = "agrian-registry" }
 
 [lib]
 crate-type = ["staticlib", "rlib"]

--- a/ffi_core/Cargo.toml
+++ b/ffi_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_core"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]

--- a/ffi_derive/Cargo.toml
+++ b/ffi_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_derive"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
@@ -10,9 +10,9 @@ repository = "https://github.com/agrian-inc/ffi_common"
 proc-macro = true
 
 [dependencies]
-ffi_internals = { version = "0.5.1", registry = "agrian-registry" }
+ffi_internals = { version = "0.6.0", registry = "agrian-registry" }
 proc-macro2 = "1.0"
 proc-macro-error = "1.0"
 
 [build-dependencies]
-ffi_internals = { version = "0.5.1", registry = "agrian-registry" }
+ffi_internals = { version = "0.6.0", registry = "agrian-registry" }

--- a/ffi_internals/Cargo.toml
+++ b/ffi_internals/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffi_internals"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Nicholas Smillie <nicholas@agrian.com>"]
 edition = "2018"
 publish = ["agrian-registry"]
@@ -10,7 +10,7 @@ repository = "https://github.com/agrian-inc/ffi_common"
 
 [dependencies]
 chrono = "0.4"
-ffi_core = { version = "0.5.1", registry = "agrian-registry" }
+ffi_core = { version = "0.6.0", registry = "agrian-registry" }
 heck = "0.3"
 lazy_static = "1.4.0"
 paste = "1.0.0"


### PR DESCRIPTION
- ffi_core: Bump to 0.6.0
- ffi_internals: Bump to 0.6.0
- ffi_derive: Bump to 0.6.0
- ffi_common: Bump to 0.6.0
