### PR TITLE
feature/doc comments

### DIFF
--- a/ffi_derive/src/lib.rs
+++ b/ffi_derive/src/lib.rs
@@ -375,7 +375,7 @@ fn impl_ffi_macro(ast: &DeriveInput) -> TokenStream {
     let type_name = ast.ident.clone();
     let module_name = format_ident!("{}_ffi", &type_name.to_string().to_snake_case());
     let struct_attributes = parsing::StructAttributes::from(&*ast.attrs);
-    let doc_comments = ffi_internals::parsing::parse_doc_comments(&*ast.attrs);
+    let doc_comments = ffi_internals::parsing::clone_doc_comments(&*ast.attrs);
     match &ast.data {
         Data::Struct(data) => struct_attributes.custom_attributes.as_ref().map_or_else(
             || {
@@ -531,7 +531,7 @@ pub fn expose_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         generics: impl_attributes.generics,
         impl_description,
         type_name,
-        doc_comments: parsing::parse_doc_comments(&*item_impl.attrs),
+        doc_comments: parsing::clone_doc_comments(&*item_impl.attrs),
     });
     let out_dir = out_dir();
     let file_name = impl_ffi.consumer_file_name();

--- a/ffi_derive/src/lib.rs
+++ b/ffi_derive/src/lib.rs
@@ -375,6 +375,7 @@ fn impl_ffi_macro(ast: &DeriveInput) -> TokenStream {
     let type_name = ast.ident.clone();
     let module_name = format_ident!("{}_ffi", &type_name.to_string().to_snake_case());
     let struct_attributes = parsing::StructAttributes::from(&*ast.attrs);
+    let doc_comments = ffi_internals::parsing::parse_doc_comments(&*ast.attrs);
     match &ast.data {
         Data::Struct(data) => struct_attributes.custom_attributes.as_ref().map_or_else(
             || {
@@ -386,6 +387,7 @@ fn impl_ffi_macro(ast: &DeriveInput) -> TokenStream {
                     consumer_imports: &struct_attributes.consumer_imports,
                     ffi_mod_imports: &struct_attributes.ffi_mod_imports,
                     forbid_memberwise_init: struct_attributes.forbid_memberwise_init,
+                    doc_comments: &doc_comments,
                 });
                 (&ConsumerStruct::from(&ffi)).write_output(&out_dir);
                 proc_macro2::TokenStream::from(ffi)
@@ -399,6 +401,7 @@ fn impl_ffi_macro(ast: &DeriveInput) -> TokenStream {
                     &*struct_attributes.consumer_imports,
                     &*struct_attributes.ffi_mod_imports,
                     struct_attributes.forbid_memberwise_init,
+                    &doc_comments,
                 );
                 (&ConsumerStruct::from(&ffi)).write_output(&out_dir);
                 proc_macro2::TokenStream::from(ffi)
@@ -417,6 +420,7 @@ fn impl_ffi_macro(ast: &DeriveInput) -> TokenStream {
                     &*struct_attributes.alias_modules,
                     &*struct_attributes.consumer_imports,
                     &*struct_attributes.ffi_mod_imports,
+                    &doc_comments,
                 );
                 (&consumer_enum::ComplexConsumerEnum::from(&ffi)).write_output(&out_dir);
                 proc_macro2::TokenStream::from(ffi)
@@ -527,6 +531,7 @@ pub fn expose_impl(attr: TokenStream, item: TokenStream) -> TokenStream {
         generics: impl_attributes.generics,
         impl_description,
         type_name,
+        doc_comments: parsing::parse_doc_comments(&*item_impl.attrs),
     });
     let out_dir = out_dir();
     let file_name = impl_ffi.consumer_file_name();

--- a/ffi_internals/src/consumer.rs
+++ b/ffi_internals/src/consumer.rs
@@ -29,8 +29,8 @@
 #![allow(clippy::module_name_repetitions)]
 
 use heck::CamelCase;
-use proc_macro_error::{ResultExt, abort};
-use syn::{Attribute, spanned::Spanned};
+use proc_macro_error::{abort, ResultExt};
+use syn::{spanned::Spanned, Attribute};
 
 mod error;
 mod primitives_conformance;
@@ -70,19 +70,22 @@ pub fn write_consumer_foundation(consumer_dir: &str, language: &str) -> Result<(
 }
 
 /// Converts a slice of doc comment attributes to a string of correctly formatted consumer comments.
-/// 
+///
 /// `attrs` must be doc comments, or this will abort the proc macro.
 /// `indentation_level` should be the number of levels that the type on this comment is nested. It
 /// will be multiplied by `TAB_SIZE`.
-/// 
+///
 /// Note that the returned `String` ends in a newline, so you don't need to (and shouldn't) push an
 /// additional newline before pushing the consumer content.
-/// 
+///
 fn consumer_docs_from(attrs: &[Attribute], indentation_level: usize) -> String {
     let mut docs = attrs
         .iter()
         .filter_map(|attr| {
-            if let syn::Meta::NameValue(meta) = attr.parse_meta().expect_or_abort("Cannot parse meta for doc comment.") {
+            if let syn::Meta::NameValue(meta) = attr
+                .parse_meta()
+                .expect_or_abort("Cannot parse meta for doc comment.")
+            {
                 if let syn::Lit::Str(lit) = meta.lit {
                     let doc = lit.value();
                     if doc.is_empty() {
@@ -96,7 +99,9 @@ fn consumer_docs_from(attrs: &[Attribute], indentation_level: usize) -> String {
         .map(|doc| format_doc(&doc, indentation_level))
         .collect::<Vec<String>>()
         .join("\n");
-    if !docs.is_empty() { docs.push('\n') }
+    if !docs.is_empty() {
+        docs.push('\n');
+    }
     docs
 }
 
@@ -166,31 +171,31 @@ pub trait ConsumerType {
     fn type_name(&self) -> String;
 
     /// The type definition.
-    /// 
+    ///
     /// This should not include leading or trailing newlines.
     ///
     fn type_definition(&self) -> Option<String>;
 
     /// The implementation of the `NativeData` protocol.
-    /// 
+    ///
     /// This should not include leading or trailing newlines.
-    /// 
+    ///
     fn native_data_impl(&self) -> String;
 
     /// The implementation of the `FFIArray` protocol.
-    /// 
+    ///
     /// This should not include leading or trailing newlines.
     ///
     fn ffi_array_impl(&self) -> String;
 
     /// The implementation of the `NativeArrayData` protocol.
-    /// 
+    ///
     /// This should not include leading or trailing newlines.
     ///
     fn native_array_data_impl(&self) -> String;
 
     /// The implementation for handling optional instances of this type.
-    /// 
+    ///
     /// This should not include leading or trailing newlines.
     ///
     fn option_impl(&self) -> String;
@@ -268,9 +273,11 @@ fn build_imports(paths: &[syn::Path]) -> Vec<String> {
 fn header_and_imports(additional_imports: &[syn::Path]) -> String {
     let mut output = HEADER.to_string();
     output.push_str("\n\n");
-    output.push_str(&option_env!("FFI_COMMON_FRAMEWORK")
-        .map(|f| format!("import {}", f))
-        .unwrap_or_default());
+    output.push_str(
+        &option_env!("FFI_COMMON_FRAMEWORK")
+            .map(|f| format!("import {}", f))
+            .unwrap_or_default(),
+    );
 
     if !additional_imports.is_empty() {
         output.push('\n');

--- a/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
@@ -70,7 +70,7 @@ impl ComplexConsumerEnum<'_> {
 
     fn ffi_declaration(&self) -> String {
         format!(
-r#"{spacer:l1$}public final class FFI {{
+            r#"{spacer:l1$}public final class FFI {{
 {spacer:l2$}internal let pointer: OpaquePointer
 
 {spacer:l2$}internal init(_ pointer: OpaquePointer) {{
@@ -91,7 +91,7 @@ r#"{spacer:l1$}public final class FFI {{
 
     fn enum_protocol_conformance(&self) -> String {
         format!(
-r#"// MARK: - ForeignEnum
+            r#"// MARK: - ForeignEnum
 extension {type_name}.FFI: ForeignEnum {{
 {spacer:l1$}public typealias NativeEnumType = {type_name}
 
@@ -206,7 +206,7 @@ extension {type_name}: NativeEnum {{
                     })
                     .collect();
                 format!(
-r#"{spacer:l2$}case {ffi_variant_ident}:
+                    r#"{spacer:l2$}case {ffi_variant_ident}:
 {spacer:l3$}return .{consumer_variant_ident}(
 {field_getters},
 {spacer:l4$}self
@@ -250,7 +250,7 @@ impl ConsumerType for ComplexConsumerEnum<'_> {
     fn type_definition(&self) -> Option<String> {
         let mut result = crate::consumer::consumer_docs_from(self.enum_ffi.doc_comments, 0);
         result.push_str(&format!(
-r#"public enum {type_name} {{
+            r#"public enum {type_name} {{
 {case_definitions}
 
 {case_inits}
@@ -273,7 +273,7 @@ extension {type_name} {{
 
     fn native_data_impl(&self) -> String {
         format!(
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension {type_name}.FFI: NativeData {{
 {spacer:l1$}public typealias ForeignType = OpaquePointer?
 
@@ -329,7 +329,7 @@ extension {type_name}: NativeData {{
 
     fn ffi_array_impl(&self) -> String {
         format!(
-r#"extension {array_name}: FFIArray {{
+            r#"extension {array_name}: FFIArray {{
 {spacer:l1$}public typealias Value = OpaquePointer?
 
 {spacer:l1$}public static func from(ptr: UnsafePointer<Value>?, len: Int) -> Self {{
@@ -351,7 +351,7 @@ r#"extension {array_name}: FFIArray {{
 
     fn native_array_data_impl(&self) -> String {
         format!(
-r#"// MARK: - NativeArrayData
+            r#"// MARK: - NativeArrayData
 extension {type_name}.FFI: NativeArrayData {{
 {spacer:l1$}public typealias FFIArrayType = {array_type_name}
 }}
@@ -368,7 +368,7 @@ extension {type_name}: NativeArrayData {{
 
     fn option_impl(&self) -> String {
         format!(
-r#"// MARK: - Optional
+            r#"// MARK: - Optional
 public extension Optional where Wrapped == {type_name}.FFI {{
 {spacer:l1$}func clone() -> OpaquePointer? {{
 {spacer:l2$}switch self {{
@@ -551,7 +551,7 @@ mod tests {
         };
         assert_eq!(
             complex_consumer_enum.type_definition().unwrap(),
-r#"public enum TestType {
+            r#"public enum TestType {
     case variant1(UInt16, TestType.FFI)
     case variant2(UInt8, TestType.FFI)
 
@@ -634,7 +634,7 @@ extension TestType: NativeEnum {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -695,7 +695,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -756,7 +756,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -817,7 +817,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 

--- a/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
@@ -76,8 +76,7 @@ impl ComplexConsumerEnum<'_> {
 
     fn ffi_declaration(&self) -> String {
         format!(
-            r#"
-{spacer:l1$}public final class FFI {{
+r#"{spacer:l1$}public final class FFI {{
 {spacer:l2$}internal let pointer: OpaquePointer
 
 {spacer:l2$}internal init(_ pointer: OpaquePointer) {{
@@ -87,8 +86,7 @@ impl ComplexConsumerEnum<'_> {
 {spacer:l2$}deinit {{
 {spacer:l3$}{free_fn_name}(pointer)
 {spacer:l2$}}}
-{spacer:l1$}}}
-"#,
+{spacer:l1$}}}"#,
             spacer = " ",
             l1 = TAB_SIZE,
             l2 = TAB_SIZE * 2,
@@ -99,7 +97,7 @@ impl ComplexConsumerEnum<'_> {
 
     fn enum_protocol_conformance(&self) -> String {
         format!(
-            r#"// MARK: - ForeignEnum
+r#"// MARK: - ForeignEnum
 extension {type_name}.FFI: ForeignEnum {{
 {spacer:l1$}public typealias NativeEnumType = {type_name}
 
@@ -214,13 +212,11 @@ extension {type_name}: NativeEnum {{
                     })
                     .collect();
                 format!(
-                    r#"
-{spacer:l2$}case {ffi_variant_ident}:
+r#"{spacer:l2$}case {ffi_variant_ident}:
 {spacer:l3$}return .{consumer_variant_ident}(
 {spacer:l4$}self,
 {field_getters}
-{spacer:l3$})
-"#,
+{spacer:l3$})"#,
                     spacer = " ",
                     l2 = TAB_SIZE * 2,
                     l3 = TAB_SIZE * 3,
@@ -260,8 +256,7 @@ impl ConsumerType for ComplexConsumerEnum<'_> {
     fn type_definition(&self) -> String {
         let mut result = crate::consumer::consumer_docs_from(self.enum_ffi.doc_comments, 0);
         result.push_str(&format!(
-            r#"
-public enum {type_name} {{
+r#"public enum {type_name} {{
 {case_definitions}
 
 {case_inits}
@@ -272,8 +267,7 @@ extension {type_name} {{
 {ffi_declaration}
 }}
 
-{enum_protocol_conformance}
-"#,
+{enum_protocol_conformance}"#,
             type_name = self.type_name(),
             case_definitions = self.case_definitions(),
             case_inits = self.case_inits(),
@@ -285,8 +279,7 @@ extension {type_name} {{
 
     fn native_data_impl(&self) -> String {
         format!(
-            r#"
-// MARK: - NativeData
+r#"// MARK: - NativeData
 extension {type_name}.FFI: NativeData {{
 {spacer:l1$}public typealias ForeignType = OpaquePointer?
 
@@ -331,8 +324,7 @@ extension {type_name}: NativeData {{
 {spacer:l1$}public static func fromRust(_ foreignObject: FFIType.ForeignType) -> Self {{
 {spacer:l2$}Self.FFIType.fromRust(foreignObject).makeNative()
 {spacer:l1$}}}
-}}
-"#,
+}}"#,
             spacer = " ",
             l1 = TAB_SIZE,
             l2 = TAB_SIZE * 2,
@@ -343,8 +335,7 @@ extension {type_name}: NativeData {{
 
     fn ffi_array_impl(&self) -> String {
         format!(
-            r#"
-extension {array_name}: FFIArray {{
+r#"extension {array_name}: FFIArray {{
 {spacer:l1$}public typealias Value = OpaquePointer?
 
 {spacer:l1$}public static func from(ptr: UnsafePointer<Value>?, len: Int) -> Self {{
@@ -354,8 +345,7 @@ extension {array_name}: FFIArray {{
 {spacer:l1$}public static func free(_ array: Self) {{
 {spacer:l2$}{array_free_fn_name}(array)
 {spacer:l1$}}}
-}}
-"#,
+}}"#,
             spacer = " ",
             l1 = TAB_SIZE,
             l2 = TAB_SIZE * 2,
@@ -367,16 +357,14 @@ extension {array_name}: FFIArray {{
 
     fn native_array_data_impl(&self) -> String {
         format!(
-            r#"
-// MARK: - NativeArrayData
+r#"// MARK: - NativeArrayData
 extension {type_name}.FFI: NativeArrayData {{
 {spacer:l1$}public typealias FFIArrayType = {array_type_name}
 }}
 
 extension {type_name}: NativeArrayData {{
 {spacer:l1$}public typealias FFIArrayType = {array_type_name}
-}}
-"#,
+}}"#,
             spacer = " ",
             l1 = TAB_SIZE,
             type_name = self.type_name(),
@@ -386,8 +374,7 @@ extension {type_name}: NativeArrayData {{
 
     fn option_impl(&self) -> String {
         format!(
-            r#"
-// MARK: - Optional
+r#"// MARK: - Optional
 public extension Optional where Wrapped == {type_name}.FFI {{
 {spacer:l1$}func clone() -> OpaquePointer? {{
 {spacer:l2$}switch self {{
@@ -440,8 +427,7 @@ public extension Optional where Wrapped == {type_name} {{
 {spacer:l2$}}}
 {spacer:l2$}return Wrapped.fromRust(ptr)
 {spacer:l1$}}}
-}}
-"#,
+}}"#,
             spacer = " ",
             l1 = TAB_SIZE,
             l2 = TAB_SIZE * 2,
@@ -571,8 +557,7 @@ mod tests {
         };
         assert_eq!(
             complex_consumer_enum.type_definition(),
-            r#"
-public enum TestType {
+r#"public enum TestType {
     case variant1(TestType.FFI, UInt16)
     case variant2(TestType.FFI, UInt8)
 
@@ -645,8 +630,7 @@ extension TestType: NativeEnum {
     public static func fromRust(pointer: FFIType.ForeignType) -> Self {
         return FFI.fromRust(pointer).makeNative()
     }
-}
-"#
+}"#
         );
     }
 
@@ -662,8 +646,7 @@ extension TestType: NativeEnum {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-            r#"
-// MARK: - NativeData
+r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -708,8 +691,7 @@ extension TestType: NativeData {
     public static func fromRust(_ foreignObject: FFIType.ForeignType) -> Self {
         Self.FFIType.fromRust(foreignObject).makeNative()
     }
-}
-"#
+}"#
         );
     }
 
@@ -725,8 +707,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-            r#"
-// MARK: - NativeData
+r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -771,8 +752,7 @@ extension TestType: NativeData {
     public static func fromRust(_ foreignObject: FFIType.ForeignType) -> Self {
         Self.FFIType.fromRust(foreignObject).makeNative()
     }
-}
-"#
+}"#
         );
     }
 
@@ -788,8 +768,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-            r#"
-// MARK: - NativeData
+r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -834,8 +813,7 @@ extension TestType: NativeData {
     public static func fromRust(_ foreignObject: FFIType.ForeignType) -> Self {
         Self.FFIType.fromRust(foreignObject).makeNative()
     }
-}
-"#
+}"#
         );
     }
 
@@ -851,8 +829,7 @@ extension TestType: NativeData {
         };
         assert_eq!(
             complex_consumer_enum.native_data_impl(),
-            r#"
-// MARK: - NativeData
+r#"// MARK: - NativeData
 extension TestType.FFI: NativeData {
     public typealias ForeignType = OpaquePointer?
 
@@ -897,8 +874,7 @@ extension TestType: NativeData {
     public static func fromRust(_ foreignObject: FFIType.ForeignType) -> Self {
         Self.FFIType.fromRust(foreignObject).makeNative()
     }
-}
-"#
+}"#
         );
     }
 }

--- a/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
@@ -39,10 +39,10 @@ impl ConsumerType for ReprCConsumerEnum<'_> {
         self.type_name_ident().to_string()
     }
 
-    fn type_definition(&self) -> String {
+    fn type_definition(&self) -> Option<String> {
         // There's no type definition for repr(C) enums; instead, we extend the FFI enum since it's
         // usable as-is.
-        String::default()
+        None
     }
 
     fn native_data_impl(&self) -> String {
@@ -165,7 +165,7 @@ mod tests {
     fn test_type_definition() {
         let ident = format_ident!("TestType");
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
-        assert!(repr_c_enum.type_definition().is_empty());
+        assert!(repr_c_enum.type_definition().is_none());
     }
 
     #[test]

--- a/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
@@ -47,7 +47,7 @@ impl ConsumerType for ReprCConsumerEnum<'_> {
 
     fn native_data_impl(&self) -> String {
         format!(
-"// MARK: - NativeData
+            "// MARK: - NativeData
 extension {type_name}: NativeData {{
     public typealias ForeignType = {type_name}
 
@@ -69,7 +69,7 @@ extension {type_name}: NativeData {{
 
     fn ffi_array_impl(&self) -> String {
         format!(
-"// MARK: - FFIArray
+            "// MARK: - FFIArray
 extension {array_name}: FFIArray {{
     public typealias Value = {type_name}
 
@@ -90,7 +90,7 @@ extension {array_name}: FFIArray {{
 
     fn native_array_data_impl(&self) -> String {
         format!(
-"// MARK: - NativeArrayData
+            "// MARK: - NativeArrayData
 extension {type_name}: NativeArrayData {{
     public typealias FFIArrayType = {array_name}
 }}",
@@ -101,7 +101,7 @@ extension {type_name}: NativeArrayData {{
 
     fn option_impl(&self) -> String {
         format!(
-"// MARK: - Optional
+            "// MARK: - Optional
 public extension Optional where Wrapped == {type_name} {{
     func clone() -> UnsafeMutablePointer<{type_name}>? {{
         switch self {{
@@ -174,7 +174,7 @@ mod tests {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.native_data_impl(),
-r#"// MARK: - NativeData
+            r#"// MARK: - NativeData
 extension TestType: NativeData {
     public typealias ForeignType = TestType
 
@@ -199,7 +199,7 @@ extension TestType: NativeData {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.ffi_array_impl(),
-r#"// MARK: - FFIArray
+            r#"// MARK: - FFIArray
 extension FFIArrayTestType: FFIArray {
     public typealias Value = TestType
 
@@ -220,7 +220,7 @@ extension FFIArrayTestType: FFIArray {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.native_array_data_impl(),
-r#"// MARK: - NativeArrayData
+            r#"// MARK: - NativeArrayData
 extension TestType: NativeArrayData {
     public typealias FFIArrayType = FFIArrayTestType
 }"#
@@ -233,7 +233,7 @@ extension TestType: NativeArrayData {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.option_impl(),
-r#"// MARK: - Optional
+            r#"// MARK: - Optional
 public extension Optional where Wrapped == TestType {
     func clone() -> UnsafeMutablePointer<TestType>? {
         switch self {

--- a/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/repr_c_enum.rs
@@ -47,7 +47,7 @@ impl ConsumerType for ReprCConsumerEnum<'_> {
 
     fn native_data_impl(&self) -> String {
         format!(
-            "
+"// MARK: - NativeData
 extension {type_name}: NativeData {{
     public typealias ForeignType = {type_name}
 
@@ -62,15 +62,14 @@ extension {type_name}: NativeData {{
     public static func fromRust(_ foreignObject: ForeignType) -> Self {{
         return foreignObject
     }}
-}}
-",
+}}",
             type_name = self.type_name_ident(),
         )
     }
 
     fn ffi_array_impl(&self) -> String {
         format!(
-            "
+"// MARK: - FFIArray
 extension {array_name}: FFIArray {{
     public typealias Value = {type_name}
 
@@ -81,8 +80,7 @@ extension {array_name}: FFIArray {{
     public static func free(_ array: Self) {{
         {array_free_fn_name}(array)
     }}
-}}
-",
+}}",
             array_name = self.array_name(),
             type_name = self.type_name_ident(),
             array_init_fn_name = self.array_init_fn_name(),
@@ -92,11 +90,10 @@ extension {array_name}: FFIArray {{
 
     fn native_array_data_impl(&self) -> String {
         format!(
-            "
+"// MARK: - NativeArrayData
 extension {type_name}: NativeArrayData {{
     public typealias FFIArrayType = {array_name}
-}}
-",
+}}",
             type_name = self.type_name_ident(),
             array_name = self.array_name(),
         )
@@ -104,7 +101,7 @@ extension {type_name}: NativeArrayData {{
 
     fn option_impl(&self) -> String {
         format!(
-            "
+"// MARK: - Optional
 public extension Optional where Wrapped == {type_name} {{
     func clone() -> UnsafeMutablePointer<{type_name}>? {{
         switch self {{
@@ -138,8 +135,7 @@ public extension Optional where Wrapped == {type_name} {{
     static func free(_ option: UnsafePointer<{type_name}>?) {{
         {option_free_fn_name}(option)
     }}
-}}
-",
+}}",
             type_name = self.type_name_ident(),
             option_init_fn_name = self.option_init_fn_name(),
             option_free_fn_name = self.option_free_fn_name(),
@@ -178,7 +174,7 @@ mod tests {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.native_data_impl(),
-            r#"
+r#"// MARK: - NativeData
 extension TestType: NativeData {
     public typealias ForeignType = TestType
 
@@ -193,8 +189,7 @@ extension TestType: NativeData {
     public static func fromRust(_ foreignObject: ForeignType) -> Self {
         return foreignObject
     }
-}
-"#
+}"#
         );
     }
 
@@ -204,7 +199,7 @@ extension TestType: NativeData {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.ffi_array_impl(),
-            r#"
+r#"// MARK: - FFIArray
 extension FFIArrayTestType: FFIArray {
     public typealias Value = TestType
 
@@ -215,8 +210,7 @@ extension FFIArrayTestType: FFIArray {
     public static func free(_ array: Self) {
         ffi_array_TestType_free(array)
     }
-}
-"#
+}"#
         );
     }
 
@@ -226,11 +220,10 @@ extension FFIArrayTestType: FFIArray {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.native_array_data_impl(),
-            r#"
+r#"// MARK: - NativeArrayData
 extension TestType: NativeArrayData {
     public typealias FFIArrayType = FFIArrayTestType
-}
-"#
+}"#
         );
     }
 
@@ -240,7 +233,7 @@ extension TestType: NativeArrayData {
         let repr_c_enum = ReprCConsumerEnum::new(&ident);
         assert_eq!(
             repr_c_enum.option_impl(),
-            r#"
+r#"// MARK: - Optional
 public extension Optional where Wrapped == TestType {
     func clone() -> UnsafeMutablePointer<TestType>? {
         switch self {
@@ -274,8 +267,7 @@ public extension Optional where Wrapped == TestType {
     static func free(_ option: UnsafePointer<TestType>?) {
         option_TestType_free(option)
     }
-}
-"#
+}"#
         );
     }
 }

--- a/ffi_internals/src/consumer/consumer_fn.rs
+++ b/ffi_internals/src/consumer/consumer_fn.rs
@@ -2,14 +2,22 @@
 //! Generates a wrapping function in the consumer's language.
 //!
 
-use crate::{heck::MixedCase, items::fn_ffi::{FnFFI, FnReceiver}, syn::Ident};
 use super::TAB_SIZE;
+use crate::{
+    heck::MixedCase,
+    items::fn_ffi::{FnFFI, FnReceiver},
+    syn::Ident,
+};
 
 impl FnFFI {
     /// Generates a consumer function for calling the foreign function produced by
     /// `self.generate_ffi(...)`.
     ///
-    pub(super) fn generate_consumer(&self, module_name: &Ident, module_docs: Option<&[syn::Attribute]>) -> String {
+    pub(super) fn generate_consumer(
+        &self,
+        module_name: &Ident,
+        module_docs: Option<&[syn::Attribute]>,
+    ) -> String {
         // Include the keyword `static` if this function doesn't take a receiver.
         let static_keyword = if self.receiver == FnReceiver::None {
             "static "
@@ -21,7 +29,9 @@ impl FnFFI {
                 || (String::new(), String::new(), String::new()),
                 crate::type_ffi::TypeFFI::consumer_return_type_components,
             );
-        let mut result = module_docs.map_or(String::default(), |docs| crate::consumer::consumer_docs_from(docs, 1));
+        let mut result = module_docs.map_or(String::default(), |docs| {
+            crate::consumer::consumer_docs_from(docs, 1)
+        });
         result.push_str(&crate::consumer::consumer_docs_from(&*self.doc_comments, 1));
         result.push_str(&format!(
 "{spacer:l1$}{static_keyword}func {consumer_fn_name}({consumer_parameters}) {return_sig} {{

--- a/ffi_internals/src/consumer/consumer_fn.rs
+++ b/ffi_internals/src/consumer/consumer_fn.rs
@@ -9,10 +9,10 @@ impl FnFFI {
     /// Generates a consumer function for calling the foreign function produced by
     /// `self.generate_ffi(...)`.
     ///
-    pub(super) fn generate_consumer(&self, module_name: &Ident) -> String {
+    pub(super) fn generate_consumer(&self, module_name: &Ident, module_docs: Option<&[syn::Attribute]>) -> String {
         // Include the keyword `static` if this function doesn't take a receiver.
         let static_keyword = if self.receiver == FnReceiver::None {
-            "static"
+            "static "
         } else {
             ""
         };
@@ -21,9 +21,10 @@ impl FnFFI {
                 || (String::new(), String::new(), String::new()),
                 crate::type_ffi::TypeFFI::consumer_return_type_components,
             );
-        let mut result = crate::consumer::consumer_docs_from(&*self.doc_comments, 1);
+        let mut result = module_docs.map_or(String::default(), |docs| crate::consumer::consumer_docs_from(docs, 1));
+        result.push_str(&crate::consumer::consumer_docs_from(&*self.doc_comments, 1));
         result.push_str(&format!(
-"{spacer:l1$}{static_keyword} func {consumer_fn_name}({consumer_parameters}) {return_sig} {{
+"{spacer:l1$}{static_keyword}func {consumer_fn_name}({consumer_parameters}) {return_sig} {{
 {spacer:l2$}{return_conversion}{ffi_fn_name}({ffi_parameters}){close_conversion}
 {spacer:l1$}}}",
             spacer = " ",
@@ -50,7 +51,7 @@ impl FnFFI {
     pub fn generate_consumer_extension(&self, consumer_type: &str, module_name: &Ident) -> String {
         // Include the keyword `static` if this function doesn't take a receiver.
         let static_keyword = if self.receiver == FnReceiver::None {
-            "static"
+            "static "
         } else {
             ""
         };
@@ -64,7 +65,7 @@ impl FnFFI {
         result.push('\n');
         result.push_str(&crate::consumer::consumer_docs_from(&*self.doc_comments, 1));
         result.push_str(&format!(
-"{spacer:l1$}{static_keyword} func {consumer_fn_name}({consumer_parameters}) {return_sig} {{
+"{spacer:l1$}{static_keyword}func {consumer_fn_name}({consumer_parameters}) {return_sig} {{
 {spacer:l2$}{return_conversion}{ffi_fn_name}({ffi_parameters}){close_conversion}
 {spacer:l1$}}}",
                         spacer = " ",
@@ -81,32 +82,8 @@ impl FnFFI {
                     ));
         result.push('\n');
         result.push('}');
-//         let extension = format!(
-// "extension {consumer_type} {{
 
-// {docs}
-// {spacer:l1$}{static_keyword} func {consumer_fn_name}({consumer_parameters}) {return_sig} {{
-// {spacer:l2$}{return_conversion}{ffi_fn_name}({ffi_parameters}){close_conversion}
-// {spacer:l1$}}}
-
-// }}
-// ",
-//             spacer = " ",
-//             l1 = TAB_SIZE,
-//             l2 = TAB_SIZE * 2,
-//             docs = crate::consumer::consumer_docs_from(&*self.doc_comments, 1),
-//             static_keyword = static_keyword,
-//             consumer_type = consumer_type,
-//             consumer_fn_name = self.fn_name.to_string().to_mixed_case(),
-//             consumer_parameters = self.consumer_parameters(),
-//             return_sig = return_sig,
-//             return_conversion = return_conversion,
-//             ffi_fn_name = self.ffi_fn_name(module_name).to_string(),
-//             ffi_parameters = self.ffi_calling_arguments(),
-//             close_conversion = close_conversion,
-//         );
-
-        [super::header_and_imports(&[]), result].join("")
+        [super::header_and_imports(&[]), result].join("\n")
     }
 
     fn consumer_parameters(&self) -> String {

--- a/ffi_internals/src/consumer/consumer_impl.rs
+++ b/ffi_internals/src/consumer/consumer_impl.rs
@@ -40,10 +40,13 @@ impl ImplFFI {
         let (module_docs_for_fn, mut result) = if self.fns.len() == 1 {
             (Some(&*self.doc_comments), String::default())
         } else {
-            (None, crate::consumer::consumer_docs_from(&*self.doc_comments, 0))
+            (
+                None,
+                crate::consumer::consumer_docs_from(&*self.doc_comments, 0),
+            )
         };
         result.push_str(&format!(
-"public extension {native_type} {{
+            "public extension {native_type} {{
 {functions}
 }}",
             native_type = self.type_name.to_string(),

--- a/ffi_internals/src/consumer/consumer_impl.rs
+++ b/ffi_internals/src/consumer/consumer_impl.rs
@@ -33,9 +33,12 @@ impl ImplFFI {
     ///
     #[must_use]
     fn generate_consumer(&self) -> String {
-        format!(
-            "
-public extension {native_type} {{
+        let mut result = crate::consumer::consumer_docs_from(&*self.doc_comments, 0);
+        if !result.is_empty() { 
+            result.push('\n');
+        }
+        result.push_str(&format!(
+"public extension {native_type} {{
 {functions}
 }}
 ",
@@ -46,7 +49,8 @@ public extension {native_type} {{
                 .map(|f| f.generate_consumer(&self.module_name()))
                 .collect::<Vec<String>>()
                 .join("\n"),
-        )
+        ));
+        result
     }
 }
 

--- a/ffi_internals/src/consumer/consumer_struct.rs
+++ b/ffi_internals/src/consumer/consumer_struct.rs
@@ -4,7 +4,10 @@
 //! native getters for reading properties from the Rust struct.
 //!
 
-use crate::{consumer::{ConsumerType, TAB_SIZE}, syn::Path};
+use crate::{
+    consumer::{ConsumerType, TAB_SIZE},
+    syn::Path,
+};
 
 mod custom;
 mod standard;
@@ -119,7 +122,7 @@ impl ConsumerType for ConsumerStruct {
     fn type_definition(&self) -> Option<String> {
         let mut result = self.docs.clone();
         result.push_str(&format!(
-"public final class {class} {{
+            "public final class {class} {{
 
 {spacer:l1$}internal let pointer: OpaquePointer",
             spacer = " ",
@@ -130,14 +133,14 @@ impl ConsumerType for ConsumerStruct {
         result.push_str("\n\n");
 
         // If we have an init_impl, push it and another pair of newlines.
-        if let Some(init_impl) = self.init_impl(){
+        if let Some(init_impl) = self.init_impl() {
             result.push_str(&init_impl);
             result.push_str("\n\n");
         }
 
         // Push the internal init, deinit, and getters.
         result.push_str(&format!(
-"{spacer:l1$}internal init(_ pointer: OpaquePointer) {{
+            "{spacer:l1$}internal init(_ pointer: OpaquePointer) {{
 {spacer:l2$}self.pointer = pointer
 {spacer:l1$}}}
 
@@ -191,7 +194,7 @@ extension {type_name}: NativeData {{
 
     fn ffi_array_impl(&self) -> String {
         format!(
-"// MARK: - FFIArray
+            "// MARK: - FFIArray
 extension {array_name}: FFIArray {{
 {spacer:l1$}public typealias Value = OpaquePointer?
 
@@ -214,7 +217,7 @@ extension {array_name}: FFIArray {{
 
     fn native_array_data_impl(&self) -> String {
         format!(
-"// MARK: - NativeArrayData
+            "// MARK: - NativeArrayData
 extension {type_name}: NativeArrayData {{
 {spacer:l1$}public typealias FFIArrayType = {array_name}
 }}",
@@ -227,7 +230,7 @@ extension {type_name}: NativeArrayData {{
 
     fn option_impl(&self) -> String {
         format!(
-"// MARK: - Optional
+            "// MARK: - Optional
 public extension Optional where Wrapped == {type_name} {{
 {spacer:l1$}func clone() -> OpaquePointer? {{
 {spacer:l2$}switch self {{

--- a/ffi_internals/src/consumer/consumer_struct.rs
+++ b/ffi_internals/src/consumer/consumer_struct.rs
@@ -116,7 +116,7 @@ impl ConsumerType for ConsumerStruct {
     /// Generates a wrapper for a struct so that the native interface in the consumer's language
     /// correctly wraps the generated FFI module.
     ///
-    fn type_definition(&self) -> String {
+    fn type_definition(&self) -> Option<String> {
         let mut result = self.docs.clone();
         result.push_str(&format!(
 "public final class {class} {{
@@ -153,7 +153,7 @@ impl ConsumerType for ConsumerStruct {
             free_fn_name = self.free_fn_name,
             getters = self.consumer_getters
         ));
-        result
+        Some(result)
     }
 
     fn native_data_impl(&self) -> String {

--- a/ffi_internals/src/consumer/consumer_struct.rs
+++ b/ffi_internals/src/consumer/consumer_struct.rs
@@ -46,6 +46,9 @@ pub struct ConsumerStruct {
     /// generated memberwise init bypasses those restrictions.
     ///
     forbid_memberwise_init: bool,
+    /// Documentation comments on this struct.
+    ///
+    docs: String,
 }
 
 impl ConsumerStruct {
@@ -114,9 +117,9 @@ impl ConsumerType for ConsumerStruct {
     /// correctly wraps the generated FFI module.
     ///
     fn type_definition(&self) -> String {
-        format!(
-            "
-public final class {class} {{
+        let mut result = self.docs.clone();
+        result.push_str(&format!(
+"public final class {class} {{
 
     internal let pointer: OpaquePointer
 
@@ -136,7 +139,8 @@ public final class {class} {{
             init_impl = self.init_impl(),
             free_fn_name = self.free_fn_name,
             getters = self.consumer_getters
-        )
+        ));
+        result
     }
 
     fn native_data_impl(&self) -> String {

--- a/ffi_internals/src/consumer/consumer_struct/custom.rs
+++ b/ffi_internals/src/consumer/consumer_struct/custom.rs
@@ -23,10 +23,9 @@ impl custom::StructFFI<'_> {
             .iter()
             .map(|x| crate::consumer::get_segment_ident(x.segments.last()))
             .collect();
-        self.getters
-            .iter()
-            .enumerate()
-            .fold(String::new(), |mut acc, (index, (getter_ident, getter_type))| {
+        self.getters.iter().enumerate().fold(
+            String::new(),
+            |mut acc, (index, (getter_ident, getter_type))| {
                 // We're going to give things an internal access modifier if they're failable on the
                 // Rust side. This will require some additional (handwritten) Swift code for error
                 // handling before they can be accessed outside of the framework that contains the
@@ -49,7 +48,7 @@ impl custom::StructFFI<'_> {
                 };
 
                 acc.push_str(&format!(
-"{spacer:l1$}{access_modifier} var {consumer_getter_name}: {consumer_type} {{
+                    "{spacer:l1$}{access_modifier} var {consumer_getter_name}: {consumer_type} {{
 {spacer:l2$}{consumer_type}.fromRust({getter_ident}(pointer))
 {spacer:l1$}}}",
                     spacer = " ",
@@ -61,9 +60,12 @@ impl custom::StructFFI<'_> {
                     getter_ident = getter_ident.to_string()
                 ));
                 // Push an extra line between var declarations.
-                if index < self.getters.len() - 1 { acc.push_str("\n\n") }
+                if index < self.getters.len() - 1 {
+                    acc.push_str("\n\n");
+                }
                 acc
-            })
+            },
+        )
     }
 
     fn initialization_args(&self) -> InitArgs {

--- a/ffi_internals/src/consumer/consumer_struct/custom.rs
+++ b/ffi_internals/src/consumer/consumer_struct/custom.rs
@@ -124,6 +124,7 @@ impl From<&custom::StructFFI<'_>> for ConsumerStruct {
             clone_fn_name: inputs.clone_fn_name.to_string(),
             failable_init: inputs.custom_attributes.failable_init,
             forbid_memberwise_init: inputs.forbid_memberwise_init,
+            docs: crate::consumer::consumer_docs_from(inputs.doc_comments, 0),
         }
     }
 }

--- a/ffi_internals/src/consumer/consumer_struct/custom.rs
+++ b/ffi_internals/src/consumer/consumer_struct/custom.rs
@@ -25,7 +25,8 @@ impl custom::StructFFI<'_> {
             .collect();
         self.getters
             .iter()
-            .fold(String::new(), |mut acc, (getter_ident, getter_type)| {
+            .enumerate()
+            .fold(String::new(), |mut acc, (index, (getter_ident, getter_type))| {
                 // We're going to give things an internal access modifier if they're failable on the
                 // Rust side. This will require some additional (handwritten) Swift code for error
                 // handling before they can be accessed outside of the framework that contains the
@@ -48,11 +49,9 @@ impl custom::StructFFI<'_> {
                 };
 
                 acc.push_str(&format!(
-                    "
-{spacer:l1$}{access_modifier} var {consumer_getter_name}: {consumer_type} {{
+"{spacer:l1$}{access_modifier} var {consumer_getter_name}: {consumer_type} {{
 {spacer:l2$}{consumer_type}.fromRust({getter_ident}(pointer))
-{spacer:l1$}}}
-",
+{spacer:l1$}}}",
                     spacer = " ",
                     l1 = TAB_SIZE,
                     l2 = TAB_SIZE * 2,
@@ -61,6 +60,8 @@ impl custom::StructFFI<'_> {
                     consumer_type = consumer_type,
                     getter_ident = getter_ident.to_string()
                 ));
+                // Push an extra line between var declarations.
+                if index < self.getters.len() - 1 { acc.push_str("\n\n") }
                 acc
             })
     }

--- a/ffi_internals/src/consumer/consumer_struct/standard.rs
+++ b/ffi_internals/src/consumer/consumer_struct/standard.rs
@@ -95,6 +95,7 @@ impl From<&standard::StructFFI<'_>> for ConsumerStruct {
             clone_fn_name: struct_ffi.clone_fn_name().to_string(),
             failable_init: false,
             forbid_memberwise_init: struct_ffi.forbid_memberwise_init,
+            docs: crate::consumer::consumer_docs_from(struct_ffi.doc_comments, 0),
         }
     }
 }

--- a/ffi_internals/src/consumer/consumer_struct/standard.rs
+++ b/ffi_internals/src/consumer/consumer_struct/standard.rs
@@ -11,7 +11,7 @@ struct ExpandedFields {
 }
 
 // This implements some additional consumer-related behavior for the type from
-// `items::struct_ffi::standard` so that we can keep all of the consumer-related code isolated to 
+// `items::struct_ffi::standard` so that we can keep all of the consumer-related code isolated to
 // the `ffi_internals::consumer` module.
 impl standard::StructFFI<'_> {
     /// Expands this struct's fields to their corresponding consumer initializer arguments, FFI
@@ -55,7 +55,7 @@ impl standard::StructFFI<'_> {
                     ));
                     // This looks like `public var foo: Bar { Bar.fromRust(get_bar_foo(pointer) }`.
                     acc.2.push_str(&format!(
-"{spacer:l1$}public var {field}: {type_name} {{
+                        "{spacer:l1$}public var {field}: {type_name} {{
 {spacer:l2$}{type_name}.fromRust({getter}(pointer))
 {spacer:l1$}}}",
                         spacer = " ",
@@ -68,7 +68,9 @@ impl standard::StructFFI<'_> {
                         getter = f.getter_name().to_string()
                     ));
                     // Push an extra line between var declarations.
-                    if index < self.fields.len() - 1 { acc.2.push_str("\n\n") }
+                    if index < self.fields.len() - 1 {
+                        acc.2.push_str("\n\n");
+                    }
                     acc
                 },
             );

--- a/ffi_internals/src/consumer/consumer_struct/standard.rs
+++ b/ffi_internals/src/consumer/consumer_struct/standard.rs
@@ -55,11 +55,9 @@ impl standard::StructFFI<'_> {
                     ));
                     // This looks like `public var foo: Bar { Bar.fromRust(get_bar_foo(pointer) }`.
                     acc.2.push_str(&format!(
-                        "
-{spacer:l1$}public var {field}: {type_name} {{
+"{spacer:l1$}public var {field}: {type_name} {{
 {spacer:l2$}{type_name}.fromRust({getter}(pointer))
-{spacer:l1$}}}
-",
+{spacer:l1$}}}",
                         spacer = " ",
                         l1 = TAB_SIZE,
                         l2 = TAB_SIZE * 2,
@@ -69,6 +67,8 @@ impl standard::StructFFI<'_> {
                             .consumer_type(f.attributes.expose_as_ident()),
                         getter = f.getter_name().to_string()
                     ));
+                    // Push an extra line between var declarations.
+                    if index < self.fields.len() - 1 { acc.2.push_str("\n\n") }
                     acc
                 },
             );

--- a/ffi_internals/src/consumer/primitives_conformance.rs
+++ b/ffi_internals/src/consumer/primitives_conformance.rs
@@ -40,8 +40,7 @@ pub(super) fn generate(native_type: &str, ffi_type: &str, consumer_type: &str) -
 ///
 fn array_conformance(array_name: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-        "
-extension {}: FFIArray {{
+"extension {}: FFIArray {{
     public typealias Value = {}
 
     public static func from(ptr: UnsafePointer<Value>?, len: Int) -> Self {{
@@ -51,8 +50,7 @@ extension {}: FFIArray {{
     public static func free(_ array: Self) {{
         {}(array)
     }}
-}}
-",
+}}",
         array_name, ffi_type, init, free
     )
 }
@@ -61,8 +59,7 @@ extension {}: FFIArray {{
 ///
 fn option_conformance(consumer_type: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-        "
-public extension Optional where Wrapped == {} {{
+"public extension Optional where Wrapped == {} {{
     func clone() -> UnsafeMutablePointer<{}>? {{
         switch self {{
         case let .some(value):
@@ -95,8 +92,7 @@ public extension Optional where Wrapped == {} {{
     static func free(_ option: UnsafePointer<{}>?) {{
         {}(option)
     }}
-}}
-",
+}}",
         consumer_type, ffi_type, init, ffi_type, init, ffi_type, ffi_type, free
     )
 }
@@ -105,8 +101,7 @@ public extension Optional where Wrapped == {} {{
 ///
 fn consumer_type_base(consumer_type: &str, ffi_type: &str) -> String {
     format!(
-        "
-extension {}: NativeData {{
+"extension {}: NativeData {{
     public typealias ForeignType = {}
 
     public func clone() -> ForeignType {{
@@ -120,8 +115,7 @@ extension {}: NativeData {{
     public static func fromRust(_ foreignObject: ForeignType) -> Self {{
         return foreignObject
     }}
-}}
-",
+}}",
         consumer_type, ffi_type
     )
 }
@@ -130,11 +124,9 @@ extension {}: NativeData {{
 ///
 fn consumer_array_type(consumer_type: &str, ffi_array_type: &str) -> String {
     format!(
-        "
-extension {}: NativeArrayData {{
+"extension {}: NativeArrayData {{
     public typealias FFIArrayType = {}
-}}
-",
+}}",
         consumer_type, ffi_array_type
     )
 }

--- a/ffi_internals/src/consumer/primitives_conformance.rs
+++ b/ffi_internals/src/consumer/primitives_conformance.rs
@@ -33,14 +33,15 @@ pub(super) fn generate(native_type: &str, ffi_type: &str, consumer_type: &str) -
         consumer_type_base(consumer_type, ffi_type),
         consumer_array_type(consumer_type, &format!("FFIArray{}", native_type)),
     ]
-    .join("")
+    .join("\n\n")
 }
 
 /// Conversion from the consumer's native array type to the `FFIArray` type for `native_type`.
 ///
 fn array_conformance(array_name: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-"extension {}: FFIArray {{
+"// MARK: - FFIArray
+extension {}: FFIArray {{
     public typealias Value = {}
 
     public static func from(ptr: UnsafePointer<Value>?, len: Int) -> Self {{
@@ -59,7 +60,8 @@ fn array_conformance(array_name: &str, ffi_type: &str, init: &str, free: &str) -
 ///
 fn option_conformance(consumer_type: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-"public extension Optional where Wrapped == {} {{
+"// MARK: - Optional
+public extension Optional where Wrapped == {} {{
     func clone() -> UnsafeMutablePointer<{}>? {{
         switch self {{
         case let .some(value):
@@ -101,7 +103,8 @@ fn option_conformance(consumer_type: &str, ffi_type: &str, init: &str, free: &st
 ///
 fn consumer_type_base(consumer_type: &str, ffi_type: &str) -> String {
     format!(
-"extension {}: NativeData {{
+"// MARK: - NativeData
+extension {}: NativeData {{
     public typealias ForeignType = {}
 
     public func clone() -> ForeignType {{
@@ -124,7 +127,8 @@ fn consumer_type_base(consumer_type: &str, ffi_type: &str) -> String {
 ///
 fn consumer_array_type(consumer_type: &str, ffi_array_type: &str) -> String {
     format!(
-"extension {}: NativeArrayData {{
+"// MARK: - NativeArrayData
+extension {}: NativeArrayData {{
     public typealias FFIArrayType = {}
 }}",
         consumer_type, ffi_array_type

--- a/ffi_internals/src/consumer/primitives_conformance.rs
+++ b/ffi_internals/src/consumer/primitives_conformance.rs
@@ -40,7 +40,7 @@ pub(super) fn generate(native_type: &str, ffi_type: &str, consumer_type: &str) -
 ///
 fn array_conformance(array_name: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-"// MARK: - FFIArray
+        "// MARK: - FFIArray
 extension {}: FFIArray {{
     public typealias Value = {}
 
@@ -60,7 +60,7 @@ extension {}: FFIArray {{
 ///
 fn option_conformance(consumer_type: &str, ffi_type: &str, init: &str, free: &str) -> String {
     format!(
-"// MARK: - Optional
+        "// MARK: - Optional
 public extension Optional where Wrapped == {} {{
     func clone() -> UnsafeMutablePointer<{}>? {{
         switch self {{
@@ -103,7 +103,7 @@ public extension Optional where Wrapped == {} {{
 ///
 fn consumer_type_base(consumer_type: &str, ffi_type: &str) -> String {
     format!(
-"// MARK: - NativeData
+        "// MARK: - NativeData
 extension {}: NativeData {{
     public typealias ForeignType = {}
 
@@ -127,7 +127,7 @@ extension {}: NativeData {{
 ///
 fn consumer_array_type(consumer_type: &str, ffi_array_type: &str) -> String {
     format!(
-"// MARK: - NativeArrayData
+        "// MARK: - NativeArrayData
 extension {}: NativeArrayData {{
     public typealias FFIArrayType = {}
 }}",

--- a/ffi_internals/src/items/enum_ffi/complex.rs
+++ b/ffi_internals/src/items/enum_ffi/complex.rs
@@ -7,7 +7,7 @@ use crate::items::field_ffi::FieldFFI;
 use heck::SnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DataEnum, Ident, Path};
+use syn::{Attribute, DataEnum, Ident, Path};
 
 /// Describes a variant of an enum.
 ///
@@ -19,6 +19,10 @@ pub struct VariantFFI<'a> {
     /// The variant's fields.
     ///
     pub fields: Vec<FieldFFI<'a>>,
+
+    /// Documentation comments on this variant.
+    ///
+    pub doc_comments: Vec<Attribute>,
 }
 
 impl<'a> VariantFFI<'a> {
@@ -67,6 +71,10 @@ pub struct EnumFFI<'a> {
     /// Paths that need to be imported into the FFI module.
     ///
     pub ffi_mod_imports: &'a [Path],
+
+    /// Documentation comments on this enum.
+    ///
+    pub doc_comments: &'a [Attribute],
 }
 
 impl<'a> EnumFFI<'a> {
@@ -80,6 +88,7 @@ impl<'a> EnumFFI<'a> {
         alias_modules: &'a [String],
         consumer_imports: &'a [Path],
         ffi_mod_imports: &'a [Path],
+        doc_comments: &'a [Attribute],
     ) -> Self {
         let variants = derive
             .variants
@@ -107,6 +116,7 @@ impl<'a> EnumFFI<'a> {
                 VariantFFI {
                     ident: &variant.ident,
                     fields,
+                    doc_comments: crate::parsing::parse_doc_comments(&*variant.attrs),
                 }
             })
             .collect();
@@ -118,6 +128,7 @@ impl<'a> EnumFFI<'a> {
             alias_modules,
             consumer_imports,
             ffi_mod_imports,
+            doc_comments,
         }
     }
 

--- a/ffi_internals/src/items/enum_ffi/complex.rs
+++ b/ffi_internals/src/items/enum_ffi/complex.rs
@@ -116,7 +116,7 @@ impl<'a> EnumFFI<'a> {
                 VariantFFI {
                     ident: &variant.ident,
                     fields,
-                    doc_comments: crate::parsing::parse_doc_comments(&*variant.attrs),
+                    doc_comments: crate::parsing::clone_doc_comments(&*variant.attrs),
                 }
             })
             .collect();

--- a/ffi_internals/src/items/field_ffi.rs
+++ b/ffi_internals/src/items/field_ffi.rs
@@ -384,7 +384,7 @@ impl<'a> From<FieldInputs<'a>> for FieldFFI<'a> {
             field_source: inputs.field_source,
             native_type_data,
             attributes,
-            doc_comments: parsing::parse_doc_comments(inputs.field_attrs),
+            doc_comments: parsing::clone_doc_comments(inputs.field_attrs),
         }
     }
 }

--- a/ffi_internals/src/items/field_ffi.rs
+++ b/ffi_internals/src/items/field_ffi.rs
@@ -12,7 +12,7 @@ use parsing::FieldAttributes;
 use proc_macro2::TokenStream;
 use proc_macro_error::abort;
 use quote::{format_ident, quote};
-use syn::{spanned::Spanned, Fields, Ident};
+use syn::{spanned::Spanned, Attribute, Fields, Ident};
 
 #[derive(Debug, Clone)]
 pub(crate) enum FieldSource<'a> {
@@ -47,6 +47,10 @@ pub struct FieldFFI<'a> {
     /// The FFI helper attribute annotations on this field.
     ///
     pub attributes: FieldAttributes,
+
+    /// Documentation comments on this field.
+    ///
+    pub(crate) doc_comments: Vec<Attribute>,
 }
 
 impl<'a> FieldFFI<'a> {
@@ -249,7 +253,7 @@ pub(super) struct FieldInputs<'a> {
     pub field_ident: FieldIdent,
     pub field_type: &'a syn::Type,
     pub field_source: FieldSource<'a>,
-    pub field_attrs: &'a [syn::Attribute],
+    pub field_attrs: &'a [Attribute],
     pub alias_modules: &'a [String],
 }
 
@@ -380,6 +384,7 @@ impl<'a> From<FieldInputs<'a>> for FieldFFI<'a> {
             field_source: inputs.field_source,
             native_type_data,
             attributes,
+            doc_comments: parsing::parse_doc_comments(inputs.field_attrs),
         }
     }
 }

--- a/ffi_internals/src/items/fn_ffi.rs
+++ b/ffi_internals/src/items/fn_ffi.rs
@@ -130,7 +130,7 @@ impl<'a> From<FnFFIInputs<'a>> for FnFFI {
             receiver,
             parameters: arguments,
             return_type,
-            doc_comments: crate::parsing::parse_doc_comments(&*inputs.method.attrs),
+            doc_comments: crate::parsing::clone_doc_comments(&*inputs.method.attrs),
         }
     }
 }
@@ -183,7 +183,7 @@ impl From<(&ItemFn, &FnAttributes)> for FnFFI {
             receiver,
             parameters: arguments,
             return_type,
-            doc_comments: crate::parsing::parse_doc_comments(&*method.attrs),
+            doc_comments: crate::parsing::clone_doc_comments(&*method.attrs),
         }
     }
 }

--- a/ffi_internals/src/items/impl_ffi.rs
+++ b/ffi_internals/src/items/impl_ffi.rs
@@ -90,7 +90,7 @@ impl From<ImplInputs> for ImplFFI {
                         generics: inputs.generics.clone(),
                     },
                     local_aliases: aliases.clone(),
-                    doc_comments: crate::parsing::parse_doc_comments(&*item.attrs),
+                    doc_comments: crate::parsing::clone_doc_comments(&*item.attrs),
                 })
             })
             .collect();

--- a/ffi_internals/src/items/struct_ffi/custom.rs
+++ b/ffi_internals/src/items/struct_ffi/custom.rs
@@ -59,6 +59,7 @@ impl<'a> StructFFI<'a> {
     /// Create a new `StructFFI` from derive macro inputs.
     ///
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         type_name: &'a Ident,
         module_name: &'a Ident,

--- a/ffi_internals/src/items/struct_ffi/custom.rs
+++ b/ffi_internals/src/items/struct_ffi/custom.rs
@@ -7,7 +7,7 @@ use crate::parsing::CustomAttributes;
 use heck::SnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{Ident, Path, Type};
+use syn::{Attribute, Ident, Path, Type};
 
 /// Represents the components of a struct that has a custom FFI implementation (defined at
 /// `custom_attributes.path`).
@@ -50,6 +50,9 @@ pub struct StructFFI<'a> {
     /// generated memberwise init bypasses those restrictions.
     ///
     pub forbid_memberwise_init: bool,
+    /// Documentation comments on this struct.
+    ///
+    pub doc_comments: &'a [Attribute],
 }
 
 impl<'a> StructFFI<'a> {
@@ -64,6 +67,7 @@ impl<'a> StructFFI<'a> {
         consumer_imports: &'a [Path],
         ffi_mod_imports: &'a [Path],
         forbid_memberwise_init: bool,
+        doc_comments: &'a [Attribute],
     ) -> Self {
         let init_fn_name = format_ident!("{}_init", &type_name.to_string().to_snake_case());
         let free_fn_name = format_ident!("{}_free", &type_name.to_string().to_snake_case());
@@ -87,6 +91,7 @@ impl<'a> StructFFI<'a> {
             free_fn_name,
             clone_fn_name,
             forbid_memberwise_init,
+            doc_comments,
         }
     }
 }

--- a/ffi_internals/src/items/struct_ffi/standard.rs
+++ b/ffi_internals/src/items/struct_ffi/standard.rs
@@ -8,7 +8,7 @@ use heck::SnakeCase;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashSet;
-use syn::{spanned::Spanned, Fields, Ident, Path};
+use syn::{spanned::Spanned, Attribute, Fields, Ident, Path};
 
 /// Represents the components of a struct for generating a standard derived FFI.
 ///
@@ -46,6 +46,9 @@ pub struct StructFFI<'a> {
     /// `TokenStream`.
     ///
     getter_fns: TokenStream,
+    /// Documentation comments on this struct.
+    ///
+    pub doc_comments: &'a [Attribute],
 }
 
 impl StructFFI<'_> {
@@ -113,6 +116,8 @@ pub struct StructInputs<'a> {
     /// generated memberwise init bypasses those restrictions.
     ///
     pub forbid_memberwise_init: bool,
+    /// Documentation comments on this struct.
+    pub doc_comments: &'a [Attribute],
 }
 
 impl<'a> From<&StructInputs<'a>> for StructFFI<'a> {
@@ -159,6 +164,7 @@ impl<'a> From<&StructInputs<'a>> for StructFFI<'a> {
             assignment_expressions,
             getter_fns,
             forbid_memberwise_init: derive.forbid_memberwise_init,
+            doc_comments: derive.doc_comments,
         }
     }
 }

--- a/ffi_internals/src/parsing.rs
+++ b/ffi_internals/src/parsing.rs
@@ -85,7 +85,7 @@ pub fn is_repr_c(attrs: &[Attribute]) -> bool {
 /// attributes only.
 ///
 #[must_use]
-pub fn parse_doc_comments(attrs: &[Attribute]) -> Vec<Attribute> {
+pub fn clone_doc_comments(attrs: &[Attribute]) -> Vec<Attribute> {
     let doc_path: Path = syn::parse_str("doc").unwrap_or_abort();
     attrs
         .iter()

--- a/ffi_internals/src/parsing.rs
+++ b/ffi_internals/src/parsing.rs
@@ -81,6 +81,23 @@ pub fn is_repr_c(attrs: &[Attribute]) -> bool {
     })
 }
 
+/// Filters and clones a slice of attributes into a `Vec<Attribute>` containing doc comment
+/// attributes only.
+///
+#[must_use]
+pub fn parse_doc_comments(attrs: &[Attribute]) -> Vec<Attribute> {
+    let doc_path: Path = syn::parse_str("doc").unwrap_or_abort();
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            if attr.path != doc_path {
+                return None;
+            }
+            Some(attr.clone())
+        })
+        .collect()
+}
+
 /// Figures out the names and types of all of the arguments in the custom FFI initializer and
 /// getters for `type_name` at `path`.
 ///

--- a/ffi_internals/src/parsing/impl_attributes.rs
+++ b/ffi_internals/src/parsing/impl_attributes.rs
@@ -121,7 +121,8 @@ impl From<syn::AttributeArgs> for ImplAttributes {
                         m.span(),
                         "Unsupported ffi attribute {:?} -- expected `ffi_imports`, \
 `consumer_imports`, `raw_types`, `description`, or `generic`, ",
-                        m.path())
+                        m.path()
+                    )
                 }
             } else {
                 abort!(arg.span(), "Unsupported ffi attribute -- {:?}.", arg)

--- a/ffi_internals/src/parsing/struct_attributes.rs
+++ b/ffi_internals/src/parsing/struct_attributes.rs
@@ -100,7 +100,8 @@ impl From<&[Attribute]> for StructAttributes {
                         other.span(),
                         "Unsupported ffi attribute -- only \
 `custom`, `alias_modules`, `consumer_imports`, `ffi_mod_imports`, `failable_init`, `failable_fns`, \
-and `forbid_memberwise_init` are allowed in this position.");
+and `forbid_memberwise_init` are allowed in this position."
+                    );
                 }
             }
         }

--- a/ffi_internals/src/parsing/struct_attributes.rs
+++ b/ffi_internals/src/parsing/struct_attributes.rs
@@ -100,8 +100,7 @@ impl From<&[Attribute]> for StructAttributes {
                         other.span(),
                         "Unsupported ffi attribute -- only \
 `custom`, `alias_modules`, `consumer_imports`, `ffi_mod_imports`, `failable_init`, `failable_fns`, \
-and `forbid_memberwise_init` are allowed in this position."
-                    );
+and `forbid_memberwise_init` are allowed in this position.");
                 }
             }
         }


### PR DESCRIPTION
- Dupe Rust comments to FFI and consumer implementations. Still working out some spacing issues on the consumer side.
- Expose comments from Rust to FFI and consumer.
- Move the internal FFI associated value to the end of the associated values list since it'll be ignored by consumers.
