### PR TITLE
Fix for syn removing `__TestExhaustive`.

### DIFF
--- a/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
+++ b/ffi_internals/src/consumer/consumer_enum/complex_enum.rs
@@ -485,7 +485,6 @@ mod tests {
                             field_name: FieldIdent::UnnamedField(0),
                             field_source: FieldSource::Enum {
                                 variant_ident: variant_1,
-                                variant_fields_len: 1,
                                 other_variants: vec![(variant_2.clone(), 1)],
                             },
                             native_type_data: TypeFFI {
@@ -500,7 +499,6 @@ mod tests {
                                 expose_as: None,
                                 raw: false,
                             },
-                            doc_comments: vec![],
                         }],
                         doc_comments: vec![],
                     },
@@ -511,7 +509,6 @@ mod tests {
                             field_name: FieldIdent::UnnamedField(0),
                             field_source: FieldSource::Enum {
                                 variant_ident: variant_2,
-                                variant_fields_len: 1,
                                 other_variants: vec![(variant_1.clone(), 1)],
                             },
                             native_type_data: TypeFFI {
@@ -526,7 +523,6 @@ mod tests {
                                 expose_as: None,
                                 raw: false,
                             },
-                            doc_comments: vec![],
                         }],
                         doc_comments: vec![],
                     },

--- a/ffi_internals/src/items/field_ffi.rs
+++ b/ffi_internals/src/items/field_ffi.rs
@@ -19,7 +19,6 @@ pub(crate) enum FieldSource<'a> {
     Struct,
     Enum {
         variant_ident: &'a Ident,
-        variant_fields_len: usize,
         other_variants: Vec<(Ident, usize)>,
     },
 }
@@ -47,10 +46,6 @@ pub struct FieldFFI<'a> {
     /// The FFI helper attribute annotations on this field.
     ///
     pub attributes: FieldAttributes,
-
-    /// Documentation comments on this field.
-    ///
-    pub(crate) doc_comments: Vec<Attribute>,
 }
 
 impl<'a> FieldFFI<'a> {
@@ -67,7 +62,6 @@ impl<'a> FieldFFI<'a> {
         getter_name.push('_');
         if let FieldSource::Enum {
             variant_ident,
-            variant_fields_len: _,
             other_variants: _,
         } = &self.field_source
         {
@@ -115,7 +109,6 @@ impl<'a> FieldFFI<'a> {
             }
             FieldSource::Enum {
                 variant_ident,
-                variant_fields_len: _,
                 other_variants,
             } => {
                 if other_variants.iter().any(|v| &&v.0 == variant_ident) {
@@ -188,7 +181,6 @@ impl<'a> FieldFFI<'a> {
             }
             FieldSource::Enum {
                 variant_ident: _,
-                variant_fields_len: _,
                 other_variants: _,
             } => quote!(#conversion,),
         }
@@ -320,7 +312,6 @@ pub fn fields_for_variant<'a>(
             fields,
             &FieldSource::Enum {
                 variant_ident,
-                variant_fields_len: fields.named.len(),
                 other_variants,
             },
             type_name,
@@ -330,7 +321,6 @@ pub fn fields_for_variant<'a>(
             fields,
             &FieldSource::Enum {
                 variant_ident,
-                variant_fields_len: fields.unnamed.len(),
                 other_variants,
             },
             type_name,
@@ -384,7 +374,6 @@ impl<'a> From<FieldInputs<'a>> for FieldFFI<'a> {
             field_source: inputs.field_source,
             native_type_data,
             attributes,
-            doc_comments: parsing::clone_doc_comments(inputs.field_attrs),
         }
     }
 }

--- a/ffi_internals/src/items/fn_ffi.rs
+++ b/ffi_internals/src/items/fn_ffi.rs
@@ -369,10 +369,6 @@ pub(crate) struct FnParameterFFI {
     /// The type information for generating an FFI for this parameter.
     ///
     pub(crate) native_type_data: TypeFFI,
-
-    /// The original type of the fn parameter.
-    ///
-    pub(crate) original_type: Type,
 }
 
 /// Representes the inputs for building a `FnParameterFFI`.
@@ -412,7 +408,6 @@ impl<'a> From<FnParameterFFIInputs<'a>> for FnParameterFFI {
         Self {
             name,
             native_type_data,
-            original_type: *inputs.arg.ty.clone(),
         }
     }
 }

--- a/ffi_internals/src/items/impl_ffi.rs
+++ b/ffi_internals/src/items/impl_ffi.rs
@@ -75,8 +75,10 @@ impl From<ImplInputs> for ImplFFI {
                 }
                 ImplItem::Const(_)
                 | ImplItem::Macro(_)
-                | ImplItem::Verbatim(_)
-                | ImplItem::__TestExhaustive(_) => acc,
+                | ImplItem::Verbatim(_) => acc,
+                // Eventually this ought to do as suggested in https://github.com/dtolnay/syn/pull/1067, but the non_exhaustive_omitted_patterns lint
+                // isn't stable yet: https://github.com/rust-lang/rust/issues/89554.
+                _ => acc,
             });
 
         let fns = methods

--- a/ffi_internals/src/items/impl_ffi.rs
+++ b/ffi_internals/src/items/impl_ffi.rs
@@ -73,11 +73,11 @@ impl From<ImplInputs> for ImplFFI {
                     let _ignored = acc.0.insert(alias, item.ty.clone());
                     acc
                 }
-                ImplItem::Const(_)
-                | ImplItem::Macro(_)
-                | ImplItem::Verbatim(_) => acc,
                 // Eventually this ought to do as suggested in https://github.com/dtolnay/syn/pull/1067, but the non_exhaustive_omitted_patterns lint
                 // isn't stable yet: https://github.com/rust-lang/rust/issues/89554.
+                // ImplItem::Const(_)
+                // | ImplItem::Macro(_)
+                // | ImplItem::Verbatim(_) => acc,
                 _ => acc,
             });
 


### PR DESCRIPTION
Most recent version of `syn` removed the `__TestExhaustive` variant in
favor of a new lint, which is breaking downstream builds if their
`Cargo.lock` happens to pick up `syn` 1.0.90. That lint still isn't
stable, so we won't know if syn introduces a new variant there, but the
fallback is fine (the impl item for whatever new language feature would
just be ignored).

(There are some lingering warnings and it'd be nice to bring these
crates up to the 2021 edition, but I don't have time at the moment.)
