### PR TITLE
DEV-34559 Allow missing FFI_COMMON_FRAMEWORK env var

### DIFF
--- a/ffi_internals/src/consumer.rs
+++ b/ffi_internals/src/consumer.rs
@@ -273,11 +273,10 @@ fn build_imports(paths: &[syn::Path]) -> Vec<String> {
 fn header_and_imports(additional_imports: &[syn::Path]) -> String {
     let mut output = HEADER.to_string();
     output.push_str("\n\n");
-    output.push_str(
-        &option_env!("FFI_COMMON_FRAMEWORK")
-            .map(|f| format!("import {}", f))
-            .unwrap_or_default(),
-    );
+
+    if let Some(common_framework) = option_env!("FFI_COMMON_FRAMEWORK") {
+        output.push_str(&format!("import {}", common_framework));
+    }
 
     if !additional_imports.is_empty() {
         output.push('\n');


### PR DESCRIPTION
We use this env var to prepend `import SomeFramework` to generated,
non-core consumer files. This is useful for a client that wants to split
the crates they consume into multiple native frameworks, but a) that's
not needed for mobile now that things are getting trimmed, and b) we
don't need to be opinionated about how consumers organize the generated
code.
